### PR TITLE
docs: standardized CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Contributions are welcome. By participating, you agree to maintain a respectful and constructive environment.
+
+For coding standards, testing patterns, architecture guidelines, commit conventions, and all
+development practices, refer to the **[Development Guide](https://github.com/rios0rios0/guide/wiki)**.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) 1.26+
+- [Make](https://www.gnu.org/software/make/)
+
+## Development Workflow
+
+1. Fork and clone the repository
+2. Create a branch: `git checkout -b feat/my-change`
+3. Install dependencies:
+   ```bash
+   go mod download
+   ```
+4. Build the binary:
+   ```bash
+   make build
+   ```
+5. Make your changes
+6. Validate:
+   ```bash
+   make lint
+   make test
+   make sast
+   ```
+7. Update `CHANGELOG.md` under `[Unreleased]`
+8. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+9. Open a pull request against `main`

--- a/README.md
+++ b/README.md
@@ -63,23 +63,6 @@ curl -fsSL https://raw.githubusercontent.com/rios0rios0/autobump/main/install.sh
 
 Download pre-built binaries from the [releases page](https://github.com/rios0rios0/autobump/releases).
 
-### Build from Source
-
-If you'd like to compile it yourself, make sure you have Go 1.25+ and Make installed, then use the following commands:
-
-```bash
-# Download dependencies
-go mod download
-
-# Build the binary
-make build
-
-# Install system-wide (optional)
-make install
-```
-
-This will create the binary at `./bin/autobump` and optionally install it to `/usr/local/bin/autobump`.
-
 ## Configuration
 
 Create a configuration file based on the example from `configs/autobump.yaml` and put it in `~/.config/autobump.yaml`.
@@ -221,7 +204,7 @@ AutoBump will query each provider's API to find all repositories in the configur
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

- added standardized `CONTRIBUTING.md` referencing the [Development Guide](https://github.com/rios0rios0/guide/wiki)
- moved "Build from Source" section from `README.md` to `CONTRIBUTING.md`
- updated `README.md` Contributing section to link to `CONTRIBUTING.md`

## Test plan

- [ ] verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] verify `README.md` links to `CONTRIBUTING.md` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)