### PR TITLE
feat(languages): added Terraform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added Terraform support for detecting `*.tf` and `versions.tf` marker files; versions are managed through git tags (no version file update, same pattern as Go)
+
 ## [2.30.0] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ commit the changes, push the commits, and create a merge request/pull request on
 
 AutoBump supports automatic language detection and version updates for:
 
-- **Go**: Detects via `go.mod`, updates version in `go.mod`
+- **Go**: Detects via `go.mod`; versions managed through git tags (no version file)
 - **Java**: Detects via `build.gradle`, `pom.xml`, updates `build.gradle` and `application.yaml`
 - **Python**: Detects via `pyproject.toml`, `setup.py`, updates `__init__.py`
+- **Terraform**: Detects via `*.tf`, `versions.tf`; versions managed through git tags (no version file)
 - **TypeScript**: Detects via `package.json`, `tsconfig.json`, updates `package.json`
 - **C#**: Detects via `*.sln`, `*.csproj`, updates project files
 
@@ -133,7 +134,7 @@ You can manually specify the project language using the `-l` or `--language` fla
 autobump local -l java
 ```
 
-Available languages: `go`, `java`, `python`, `typescript`, `cs`
+Available languages: `go`, `java`, `python`, `terraform`, `typescript`, `cs`
 
 You can also specify a custom configuration file path:
 

--- a/configs/autobump.yaml
+++ b/configs/autobump.yaml
@@ -94,6 +94,16 @@ languages:
       - path: "{project_name}/__init__.py"
         patterns: ["(__version__\\s*=\\s*\")\\d+\\.\\d+\\.\\d+(\")"]
 
+  terraform:
+    extensions:
+      - "tf"
+      - "hcl"
+    special_patterns:
+      - "*.tf"
+      - "versions.tf"
+    # Terraform modules don't have a version file - versions are managed through git tags
+    # version_files is intentionally omitted (same pattern as Go)
+
   typescript:
     extensions:
       - "ts"

--- a/internal/domain/commands/service_test.go
+++ b/internal/domain/commands/service_test.go
@@ -96,6 +96,25 @@ func TestDetectProjectLanguage(t *testing.T) {
 		assert.Equal(t, "helm", language)
 	})
 
+	t.Run("should detect terraform by main.tf marker file", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte("terraform {\n  required_version = \">=1.9.3\"\n}\n"), 0o644))
+
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().
+			WithLanguagesConfig(map[string]entities.LanguageConfig{
+				"terraform": {SpecialPatterns: []string{"*.tf", "versions.tf"}, Extensions: []string{"tf", "hcl"}},
+			}).
+			BuildGlobalConfig()
+
+		// when
+		language, err := commands.DetectProjectLanguage(globalConfig, tmpDir)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "terraform", language)
+	})
+
 	t.Run("should return error when no language is detected", func(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
@@ -146,6 +165,21 @@ func TestResolveConfigKey(t *testing.T) {
 
 		// then
 		assert.Equal(t, "golang", result)
+	})
+
+	t.Run("should return direct match for terraform langforge constant", func(t *testing.T) {
+		// given
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().
+			WithLanguagesConfig(map[string]entities.LanguageConfig{
+				"terraform": {Extensions: []string{"tf", "hcl"}},
+			}).
+			BuildGlobalConfig()
+
+		// when
+		result := commands.ResolveConfigKey(globalConfig, langEntities.LanguageTerraform)
+
+		// then
+		assert.Equal(t, "terraform", result)
 	})
 
 	t.Run("should return empty string when no match found", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds Terraform as a first-class supported language so `autobump local` can bump CHANGELOG entries on terraform-module repositories out of the box.

langforge has already shipped a Terraform detector since `v0.5.0` (detects `*.tf`, `*.hcl`, `versions.tf`) and autobump's `langforgeAliases` map at `internal/domain/commands/service.go:119` already contains `langEntities.LanguageTerraform: {}` — but without a matching entry in the default config, `resolveConfigKey` returns `""` and autobump exits with `ErrProjectLanguageNotRecognized`. This PR closes that loop.

## Changes

- **`configs/autobump.yaml`** — added a `terraform` block with extensions `tf`/`hcl` and special patterns `*.tf`/`versions.tf`. `version_files` is intentionally omitted; Terraform modules don't carry a version in a source file — releases are git tags, same pattern as Go.
- **`internal/domain/commands/service_test.go`** — added `TestDetectProjectLanguage/should_detect_terraform_by_main.tf_marker_file` modelled on the existing Helm test, plus `TestResolveConfigKey/should_return_direct_match_for_terraform_langforge_constant` to pin the alias map behavior.
- **`README.md`** — added Terraform to the `Supported Languages` section and the `-l` flag cheat-sheet (`Available languages: go, java, python, terraform, typescript, cs`).
- **`CHANGELOG.md`** — single-line entry under `[Unreleased] / Added` following the existing convention from `[2.28.0] - added Helm chart support`.

## Validation

- `make lint` — **0 issues**
- `make test` — full suite green (8 packages, `ok`)
- Targeted unit run:
  ```
  TestDetectProjectLanguage/should_detect_terraform_by_main.tf_marker_file   PASS
  TestResolveConfigKey/should_return_direct_match_for_terraform_langforge_constant   PASS
  ```
- **End-to-end smoke test** — built from this branch and ran against a real Terraform module (`terraform-modules/helm-postgresql`):
  ```
  INFO Detecting project language
  INFO Project language detected as terraform via marker files
  INFO Opening repository at .../helm-postgresql
  INFO Bump is empty, skipping project
  ```
  (Previously the same invocation errored out with `project language not recognized`.)

## What this unblocks

The `customer-clusters` / `terraform-modules` ecosystem can now run `autobump local` on any module repo without needing a user-level `.autobump.yaml` override. I hit this friction while bumping `helm-postgresql` to `1.1.0` earlier today and had to finish the CHANGELOG edit manually — this PR makes that the happy path.

## Test plan

- [x] Lint + tests pass locally
- [x] End-to-end smoke test against a real terraform-module repo
- [ ] Reviewer verifies nothing else in the `configs/autobump.yaml` layout is disturbed (alphabetical ordering preserved, same indentation)
- [ ] Reviewer confirms the README `Supported Languages` list is the right place to surface Terraform (there's a separate `Available languages` line on ~136 that was also updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)