### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Note: The CI/CD pipeline automatically uses these scripts via the reusable workf
 
 ## Architecture
 
-The project follows **Clean Architecture** with dependencies always pointing inward toward the domain layer. Dependency injection is handled by [go.uber.org/dig](https://github.com/uber-go/dig). Provider and Git forge abstractions are sourced from the [rios0rios0/gitforge](https://github.com/rios0rios0/gitforge) library.
+The project follows **Clean Architecture** with dependencies always pointing inward toward the domain layer. Dependency injection is handled by [go.uber.org/dig](https://github.com/uber-go/dig). Provider and Git forge abstractions are sourced from the [rios0rios0/gitforge](https://github.com/rios0rios0/gitforge) library. CLI utilities (self-update, version commands, startup update checks) come from [rios0rios0/cliforge](https://github.com/rios0rios0/cliforge).
 
 ### Repository Structure
 
@@ -63,7 +63,11 @@ autobump/
 │   │   ├── commands/
 │   │   │   ├── service.go               # Use cases: ProcessRepo, IterateProjects,
 │   │   │   │                            #   DiscoverAndProcess, DetectProjectLanguage
-│   │   │   ├── container.go             # No-op RegisterProviders (commands called directly)
+│   │   │   ├── self_update.go           # SelfUpdate interface and SelfUpdateRunnerFunc type
+│   │   │   ├── self_update_command.go   # SelfUpdateCommand implementation (via cliforge)
+│   │   │   ├── version.go              # Version interface
+│   │   │   ├── version_command.go      # VersionCommand implementation
+│   │   │   ├── container.go             # RegisterProviders for command implementations via DIG
 │   │   │   ├── export_test.go           # Exports unexported functions for white-box testing
 │   │   │   └── service_test.go          # BDD unit tests for command functions
 │   │   └── entities/
@@ -82,6 +86,8 @@ autobump/
 │   │   ├── controllers/
 │   │   │   ├── local_controller.go      # "local" subcommand (single repo mode)
 │   │   │   ├── run_controller.go        # "run" subcommand (batch + discover engine)
+│   │   │   ├── self_update_controller.go # "self-update" subcommand
+│   │   │   ├── version_controller.go    # "version" subcommand
 │   │   │   ├── config_helpers.go        # Shared config reading/validation helper
 │   │   │   └── container.go             # RegisterProviders for all controllers via DIG
 │   │   └── repositories/
@@ -95,12 +101,15 @@ autobump/
 ├── test/
 │   └── domain/
 │       └── entitybuilders/
+│           ├── global_config_builder.go  # Test builder for GlobalConfig
+│           ├── project_config_builder.go # Test builder for ProjectConfig
+│           ├── provider_config_builder.go # Test builder for ProviderConfig
 │           └── repository_builder.go    # Test builder for Repository entities
 ├── configs/
 │   ├── autobump.yaml                    # Default configuration template
 │   └── CHANGELOG.template.md           # Default CHANGELOG template
 ├── Makefile                             # Build: build, debug, build-musl, run, install
-├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.26)
+├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.26.2)
 └── .github/
     └── workflows/default.yaml           # CI/CD pipeline (go-binary reusable workflow)
 ```
@@ -148,6 +157,8 @@ autobump/
 | `autobump run` | Engine mode: auto-detects batch (static project list) and/or discover (provider APIs) from config |
 | `autobump batch` | **Deprecated**: hidden alias for `run` (shows deprecation warning) |
 | `autobump discover` | **Deprecated**: hidden alias for `run` (shows deprecation warning) |
+| `autobump version` | Prints the build-time version |
+| `autobump self-update` | Downloads and installs the latest release from GitHub |
 
 ### CLI Flags
 
@@ -178,9 +189,11 @@ providers:
 
 The tool auto-detects and supports:
 
-- **Go**: Detects via `go.mod`, updates version in `go.mod`
+- **Go**: Detects via `go.mod`; versions managed through git tags (no version file)
+- **Helm**: Detects via `Chart.yaml`, updates the `version` field in `Chart.yaml`
 - **Java**: Detects via `build.gradle`, `pom.xml`, updates `build.gradle` and `application.yaml`
 - **Python**: Detects via `pyproject.toml`, `setup.py`, updates `__init__.py`
+- **Terraform**: Detects via `*.tf`, `versions.tf`; versions managed through git tags (no version file)
 - **TypeScript**: Detects via `package.json`, `tsconfig.json`, updates `package.json`
 - **C#**: Detects via `*.sln`, `*.csproj`, updates project files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document `cliforge` dependency, `version`/`self-update` commands, Helm and Terraform language support, and corrected Go version-file handling
+
 ## [2.31.4] - 2026-04-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Clean Architecture with Hexagonal (Ports & Adapters) design using `go.uber.org/d
 
 - **`cmd/autobump/`** — Entry point (`main.go`) and DI wiring (`dig.go`)
 - **`internal/domain/`** — Business logic and contracts (no framework dependencies)
-  - `commands/service.go` — Core use cases: `ProcessRepo`, `IterateProjects`, `DiscoverAndProcess`, `DetectProjectLanguage`
+  - `commands/` — Core use cases in `service.go` (`ProcessRepo`, `IterateProjects`, `DiscoverAndProcess`, `DetectProjectLanguage`) plus `VersionCommand` and `SelfUpdateCommand`
   - `entities/` — Domain types: `GlobalConfig`, `ProjectConfig`, `LanguageConfig`, `Controller` interface
 - **`internal/infrastructure/`** — Implementations
   - `controllers/` — Cobra CLI handlers: `LocalController` (single-repo), `RunController` (batch + discover engine)
@@ -56,6 +56,7 @@ Dependencies always point inward: infrastructure → domain, never the reverse.
 
 - **`gitforge`** (`github.com/rios0rios0/gitforge`) — Git provider adapters, changelog processing, PR creation
 - **`langforge`** (`github.com/rios0rios0/langforge`) — Language detection via marker files
+- **`cliforge`** (`github.com/rios0rios0/cliforge`) — CLI framework: self-update, version commands, startup update checks
 - **`testkit`** (`github.com/rios0rios0/testkit`) — Test builder base classes
 
 ### CLI Modes
@@ -63,7 +64,9 @@ Dependencies always point inward: infrastructure → domain, never the reverse.
 | Command                          | Controller        | Use Case                                                    |
 |----------------------------------|-------------------|-------------------------------------------------------------|
 | `autobump local` or `autobump .` | `LocalController` | Process a single repository                                |
-| `autobump run`                   | `RunController`   | Process repos from config (auto-detects batch vs discover) |
+| `autobump run`                   | `RunController`        | Process repos from config (auto-detects batch vs discover) |
+| `autobump version`               | `VersionController`    | Print the build-time version                               |
+| `autobump self-update`           | `SelfUpdateController` | Download and install the latest release from GitHub         |
 
 The `run` command auto-detects the mode: if the config has a `providers` section, it discovers repos via APIs; if it has a `projects` section, it iterates the static list. Both can run together.
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.