### PR TITLE
feat(versioning): add fork-aware versioning and per-project .autobump.yaml

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,6 +174,8 @@ autobump/
 - Supports `projects` list and/or `providers` list (both processed by `run` command)
 - Token resolution: inline string, `${ENV_VAR}` expansion, or file path auto-detection
 - SSH push auth: `ssh_key_path`, `ssh_key_passphrase`, `ssh_auth_sock` fields; auto-detects common SSH agent sockets (1Password, standard `ssh-agent`) when not explicitly set
+- Per-project `.autobump.yaml` discovered via `entities.FindProjectConfigFile`; `loadProjectConfigOverrides` in `internal/domain/commands/service.go` merges its `changelog_path`, `versioning`, and `languages` fields into the resolved config
+- `versioning` mode (`semver`, `fork-dot`, `fork-dash`) drives `getNextVersionString` and `updateChangelogFileString`; fork modes preserve the upstream `X.Y.Z` and skip language-specific version-file rewrites. See `internal/domain/commands/fork_version.go`
 
 ### Provider Configuration (run mode with providers)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `versioning` configuration key (global and per-project) supporting `semver`, `fork-dot`, and `fork-dash` modes for fork repositories that follow the Forking Technique
+- added per-project propagation of `versioning` through `.autobump.yaml` so forks can opt in without touching the global config
+- added fork-aware changelog bumper that increments only the trailing fork digit (e.g. `3.3.0.16` → `3.3.0.17`, `1.21.0-9` → `1.21.0-10`) and skips language-specific version-file rewrites in fork mode
+
 ### Changed
 
+- changed `loadProjectConfigOverrides` to also merge the `versioning` field from per-project `.autobump.yaml`, mirroring the existing `changelog_path` merge behavior
 - changed the Go module dependencies to their latest versions
 
 ## [2.31.6] - 2026-04-29

--- a/README.md
+++ b/README.md
@@ -210,6 +210,72 @@ autobump run
 
 AutoBump will process all configured sources (static project list and/or provider API discovery).
 
+## Per-Project Configuration (`.autobump.yaml`)
+
+Drop a `.autobump.yaml` (or `.autobump.yml`, `autobump.yaml`, `autobump.yml`) at the
+root of any repository to override settings for that project only. AutoBump
+auto-detects the file from `local`, `run`, and discovery modes, so the global
+config in `~/.config/autobump.yaml` does not need to know anything about it.
+
+The keys recognized in a per-project file are:
+
+| Key                | Purpose                                                                              |
+|--------------------|--------------------------------------------------------------------------------------|
+| `changelog_path`   | Custom changelog filename relative to the project root (e.g. `CHANGELOG_PROPRIETARY.md`) |
+| `versioning`       | Versioning mode: `semver` (default), `fork-dot`, or `fork-dash`                      |
+| `languages`        | Per-language overrides for `extensions`, `special_patterns`, and `version_files`     |
+
+```yaml
+# .autobump.yaml at the root of a fork repository
+changelog_path: 'CHANGELOG_PROPRIETARY.md'
+versioning: 'fork-dot'
+```
+
+The same keys can also be set at the global level in `~/.config/autobump.yaml`
+(under the project entry, or as top-level defaults applied to every project).
+Project-level values always win over global ones.
+
+## Versioning Modes
+
+AutoBump supports three versioning strategies, selectable via the `versioning`
+key. All three honor the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+format; only the way the next version is computed differs.
+
+| Mode        | Pattern   | Example transition       | When to use                                      |
+|-------------|-----------|--------------------------|--------------------------------------------------|
+| `semver`    | `X.Y.Z`   | `1.0.0` → `1.1.0`        | Default. Standard Semantic Versioning            |
+| `fork-dot`  | `X.Y.Z.N` | `3.3.0.16` → `3.3.0.17`  | Forks following the [Forking Technique](https://github.com/rios0rios0/guide/wiki/Forking-Technique) with a 4th increment digit |
+| `fork-dash` | `X.Y.Z-N` | `1.21.0-9` → `1.21.0-10` | Forks where CI/CD does not accept four-segment versions |
+
+In fork modes, AutoBump:
+
+- Reads the current version from the **last non-`Unreleased` header** in the changelog
+- Increments **only the trailing fork digit** (`N`); the upstream `X.Y.Z` is preserved
+- **Skips** language-specific version-file rewrites (forks typically maintain those manually or via separate pipelines)
+- Still moves `[Unreleased]` content into a freshly dated `## [<next>] - YYYY-MM-DD` section
+
+Example fork repository:
+
+```yaml
+# ~/.config/autobump.yaml
+projects:
+  - path: '~/Development/dev.azure.com/MyOrg/forks/opensearch-dashboards'
+    changelog_path: 'CHANGELOG_PROPRIETARY.md'
+    versioning: 'fork-dot'
+
+  - path: '~/Development/dev.azure.com/MyOrg/forks/oui'
+    changelog_path: 'CHANGELOG_PROPRIETARY.md'
+    versioning: 'fork-dash'
+```
+
+Or, equivalently, place a `.autobump.yaml` in each fork's root:
+
+```yaml
+# .autobump.yaml inside the opensearch-dashboards fork
+changelog_path: 'CHANGELOG_PROPRIETARY.md'
+versioning: 'fork-dot'
+```
+
 ## How It Works
 
 1. **Repository Discovery** *(run mode with providers)*: Queries GitHub, GitLab, and Azure DevOps APIs to find all repositories in configured organizations

--- a/configs/autobump.yaml
+++ b/configs/autobump.yaml
@@ -27,6 +27,14 @@ azure_devops_access_token: "azure-devops-token"
 github_access_token: "ghp_TOKEN"
 #github_access_token: ".secure_files/github_access_token.key"
 
+# (optional) global default versioning mode applied to every project that does
+# not specify its own. Accepted values: 'semver' (default), 'fork-dot', 'fork-dash'.
+# 'fork-dot' bumps X.Y.Z.N -> X.Y.Z.(N+1); 'fork-dash' bumps X.Y.Z-N -> X.Y.Z-(N+1).
+#versioning: 'semver'
+
+# (optional) global default changelog filename, relative to each project root.
+#changelog_path: 'CHANGELOG.md'
+
 # rules for automatically detecting project languages
 languages:
   # name of the language, this requires support in the code
@@ -130,8 +138,19 @@ projects:
 
   # (optional) custom changelog file path relative to the project root
   # defaults to 'CHANGELOG.md' if not specified
-  #- path: "/home/user/repo3.5"
+  #- path: '/home/user/repo3.5'
   #  changelog_path: 'docs/CHANGELOG.md'
+
+  # (optional) fork-style versioning for repositories that follow the Forking
+  # Technique (https://github.com/rios0rios0/guide/wiki/Forking-Technique).
+  # The upstream X.Y.Z is preserved; only the trailing fork digit is bumped.
+  # Use 'fork-dot' for X.Y.Z.N or 'fork-dash' for X.Y.Z-N.
+  #- path: '/home/user/forks/opensearch-dashboards'
+  #  changelog_path: 'CHANGELOG_PROPRIETARY.md'
+  #  versioning: 'fork-dot'
+  #- path: '/home/user/forks/oui'
+  #  changelog_path: 'CHANGELOG_PROPRIETARY.md'
+  #  versioning: 'fork-dash'
 
   # you can specify a project access token that will be used for this project
   # this token will be prioritized over the gitlab_access_token and the CI_JOB_TOKEN

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -61,8 +61,20 @@ var EnsureProjectLanguage = ensureProjectLanguage //nolint:gochecknoglobals // t
 // UpdateChangelogFile exports updateChangelogFile for testing.
 var UpdateChangelogFile = updateChangelogFile //nolint:gochecknoglobals // test export
 
+// UpdateChangelogFileString exports updateChangelogFileString for testing.
+var UpdateChangelogFileString = updateChangelogFileString //nolint:gochecknoglobals // test export
+
 // GetNextVersion exports getNextVersion for testing.
 var GetNextVersion = getNextVersion //nolint:gochecknoglobals // test export
+
+// GetNextVersionString exports getNextVersionString for testing.
+var GetNextVersionString = getNextVersionString //nolint:gochecknoglobals // test export
+
+// ProcessForkChangelog exports processForkChangelog for testing.
+var ProcessForkChangelog = processForkChangelog //nolint:gochecknoglobals // test export
+
+// RewriteUnreleasedAsForkRelease exports rewriteUnreleasedAsForkRelease for testing.
+var RewriteUnreleasedAsForkRelease = rewriteUnreleasedAsForkRelease //nolint:gochecknoglobals // test export
 
 // CreateChangelogIfNotExists exports createChangelogIfNotExists for testing.
 var CreateChangelogIfNotExists = createChangelogIfNotExists //nolint:gochecknoglobals // test export

--- a/internal/domain/commands/fork_pipeline_test.go
+++ b/internal/domain/commands/fork_pipeline_test.go
@@ -1,0 +1,288 @@
+//go:build unit
+
+package commands_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autobump/internal/domain/commands"
+	"github.com/rios0rios0/autobump/internal/domain/entities"
+	"github.com/rios0rios0/autobump/test/domain/entitybuilders"
+)
+
+func TestGetNextVersionString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should compute next semver version when versioning is empty", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"### Added",
+			"",
+			"- added new feature",
+			"",
+			"## [2.3.0] - 2026-03-20",
+			"",
+			"### Added",
+			"",
+			"- added previous feature",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().BuildProjectConfig()
+
+		// when
+		next, err := commands.GetNextVersionString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "2.4.0", next)
+	})
+
+	t.Run("should compute next fork-dot version when project sets fork-dot", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"### Fixed",
+			"",
+			"- fixed sidebar selected item background",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+			"",
+			"### Fixed",
+			"",
+			"- raised job timeout",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().
+			WithVersioning(entities.VersioningForkDot).
+			BuildProjectConfig()
+
+		// when
+		next, err := commands.GetNextVersionString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", next)
+	})
+
+	t.Run("should compute next fork-dash version when global sets fork-dash", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"## [Unreleased]",
+			"",
+			"### Changed",
+			"",
+			"- changed loading spinner color",
+			"",
+			"## [1.21.0-9] - 2026-01-12",
+			"",
+			"### Changed",
+			"",
+			"- changed link color",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().
+			WithVersioning(entities.VersioningForkDash).
+			BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().BuildProjectConfig()
+
+		// when
+		next, err := commands.GetNextVersionString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0-10", next)
+	})
+
+	t.Run("should let project versioning override global", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"## [Unreleased]",
+			"",
+			"### Added",
+			"",
+			"- added new feature",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().
+			WithVersioning(entities.VersioningSemver).
+			BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().
+			WithVersioning(entities.VersioningForkDot).
+			BuildProjectConfig()
+
+		// when
+		next, err := commands.GetNextVersionString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", next)
+	})
+}
+
+func TestUpdateChangelogFileString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should rewrite the changelog using fork-dot mode", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"### Fixed",
+			"",
+			"- fixed sidebar selected item background",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+			"",
+			"### Fixed",
+			"",
+			"- raised job timeout",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().
+			WithVersioning(entities.VersioningForkDot).
+			BuildProjectConfig()
+
+		// when
+		next, err := commands.UpdateChangelogFileString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", next)
+
+		raw, readErr := os.ReadFile(changelogPath)
+		require.NoError(t, readErr)
+		content := string(raw)
+		assert.Contains(t, content, "## [Unreleased]")
+		assert.Contains(t, content, "## [3.3.0.17] - ")
+		assert.Contains(t, content, "## [3.3.0.16] - 2026-04-20")
+		assert.Contains(t, content, "- fixed sidebar selected item background")
+	})
+
+	t.Run("should rewrite the changelog using fork-dash mode", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"## [Unreleased]",
+			"",
+			"### Changed",
+			"",
+			"- changed loading spinner color",
+			"",
+			"## [1.21.0-9] - 2026-01-12",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().
+			WithVersioning(entities.VersioningForkDash).
+			BuildProjectConfig()
+
+		// when
+		next, err := commands.UpdateChangelogFileString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0-10", next)
+	})
+
+	t.Run("should fall through to semver when no fork mode is set", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		changelogPath := writeChangelog(t, tmpDir, []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"### Added",
+			"",
+			"- added new feature",
+			"",
+			"## [1.0.0] - 2026-01-01",
+		})
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().BuildProjectConfig()
+
+		// when
+		next, err := commands.UpdateChangelogFileString(globalConfig, projectConfig, changelogPath)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.1.0", next)
+	})
+}
+
+func TestLoadProjectConfigOverridesPropagatesVersioning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should set versioning from per-project config when project has none", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		writeProjectConfig(t, tmpDir, "versioning: 'fork-dot'\nchangelog_path: 'CHANGELOG_PROPRIETARY.md'\n")
+
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().BuildProjectConfig()
+
+		// when
+		commands.LoadProjectConfigOverrides(globalConfig, projectConfig, tmpDir)
+
+		// then
+		assert.Equal(t, entities.VersioningForkDot, projectConfig.Versioning)
+		assert.Equal(t, "CHANGELOG_PROPRIETARY.md", projectConfig.ChangelogPath)
+	})
+
+	t.Run("should keep project versioning when project already specifies one", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		writeProjectConfig(t, tmpDir, "versioning: 'fork-dot'\n")
+
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().
+			WithVersioning(entities.VersioningForkDash).
+			BuildProjectConfig()
+
+		// when
+		commands.LoadProjectConfigOverrides(globalConfig, projectConfig, tmpDir)
+
+		// then
+		assert.Equal(t, entities.VersioningForkDash, projectConfig.Versioning)
+	})
+
+	t.Run("should leave config unchanged when no .autobump.yaml file exists", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		globalConfig := entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig()
+		projectConfig := entitybuilders.NewProjectConfigBuilder().BuildProjectConfig()
+
+		// when
+		result := commands.LoadProjectConfigOverrides(globalConfig, projectConfig, tmpDir)
+
+		// then
+		assert.Same(t, globalConfig, result)
+		assert.Empty(t, projectConfig.Versioning)
+		assert.Empty(t, projectConfig.ChangelogPath)
+	})
+}
+
+func writeProjectConfig(t *testing.T, dir, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, ".autobump.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	return p
+}

--- a/internal/domain/commands/fork_version.go
+++ b/internal/domain/commands/fork_version.go
@@ -15,9 +15,9 @@ import (
 // expected fork pattern (X.Y.Z.N or X.Y.Z-N) for the requested mode.
 var ErrInvalidForkVersion = errors.New("invalid fork version")
 
-// forkRewriteOverhead is the number of extra lines a fork-mode rewrite injects
-// into the changelog: an [Unreleased] header, a blank line, the new dated
-// header, and a trailing blank line.
+// forkRewriteOverhead is the maximum number of extra lines a fork-mode rewrite
+// may inject into the changelog: an [Unreleased] header, a blank line, the
+// new dated header, and, when another section follows, a trailing blank line.
 const forkRewriteOverhead = 4
 
 // forkVersionRegex matches the fork version forms supported by the bumper.
@@ -44,9 +44,9 @@ func (v ForkVersion) String() string {
 }
 
 // ParseForkVersion parses a fork version string into its components.
-// A trailing "v" prefix (e.g. v1.0.0.3) is tolerated but stripped from the
-// upstream part. The mode constrains which separator is accepted; pass an
-// empty mode to accept either.
+// A leading "v" prefix (e.g. v1.0.0.3) is tolerated but stripped before
+// parsing. The mode constrains which separator is accepted; pass an empty
+// mode to accept either.
 func ParseForkVersion(s, mode string) (*ForkVersion, error) {
 	trimmed := strings.TrimSpace(s)
 	trimmed = strings.TrimPrefix(trimmed, "v")

--- a/internal/domain/commands/fork_version.go
+++ b/internal/domain/commands/fork_version.go
@@ -1,0 +1,252 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rios0rios0/autobump/internal/domain/entities"
+)
+
+// ErrInvalidForkVersion is returned when a version string does not match the
+// expected fork pattern (X.Y.Z.N or X.Y.Z-N) for the requested mode.
+var ErrInvalidForkVersion = errors.New("invalid fork version")
+
+// forkRewriteOverhead is the number of extra lines a fork-mode rewrite injects
+// into the changelog: an [Unreleased] header, a blank line, the new dated
+// header, and a trailing blank line.
+const forkRewriteOverhead = 4
+
+// forkVersionRegex matches the fork version forms supported by the bumper.
+// Group 1: upstream X.Y.Z. Group 2: separator (. or -). Group 3: fork digit N.
+//
+
+var forkVersionRegex = regexp.MustCompile(`^(\d+\.\d+\.\d+)([.\-])(\d+)$`)
+
+// changelogVersionHeaderRegex matches a Keep-a-Changelog version header line.
+//
+
+var changelogVersionHeaderRegex = regexp.MustCompile(`^\s*##\s*\[([^\]]+)\]`)
+
+// ForkVersion is the parsed representation of a fork version string.
+type ForkVersion struct {
+	Upstream  string
+	Separator string
+	Fork      int
+}
+
+// String renders the fork version back to its canonical form.
+func (v ForkVersion) String() string {
+	return fmt.Sprintf("%s%s%d", v.Upstream, v.Separator, v.Fork)
+}
+
+// ParseForkVersion parses a fork version string into its components.
+// A trailing "v" prefix (e.g. v1.0.0.3) is tolerated but stripped from the
+// upstream part. The mode constrains which separator is accepted; pass an
+// empty mode to accept either.
+func ParseForkVersion(s, mode string) (*ForkVersion, error) {
+	trimmed := strings.TrimSpace(s)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+
+	matches := forkVersionRegex.FindStringSubmatch(trimmed)
+	if matches == nil {
+		return nil, fmt.Errorf("%w: %q does not match X.Y.Z.N or X.Y.Z-N", ErrInvalidForkVersion, s)
+	}
+
+	separator := matches[2]
+	if !separatorMatchesMode(separator, mode) {
+		return nil, fmt.Errorf(
+			"%w: separator %q does not match versioning mode %q",
+			ErrInvalidForkVersion, separator, mode,
+		)
+	}
+
+	forkDigit, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return nil, fmt.Errorf("%w: fork digit %q is not an integer", ErrInvalidForkVersion, matches[3])
+	}
+
+	return &ForkVersion{
+		Upstream:  matches[1],
+		Separator: separator,
+		Fork:      forkDigit,
+	}, nil
+}
+
+// NextForkVersion returns the next fork version string for the given mode.
+// The upstream segment is preserved and only the trailing fork digit is
+// incremented. If the input is empty the function returns the initial fork
+// version "0.1.0<sep>1" so that brand-new fork changelogs have a starting
+// point.
+func NextForkVersion(currentVersion, mode string) (string, error) {
+	separator, err := separatorForMode(mode)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.TrimSpace(currentVersion) == "" {
+		return fmt.Sprintf("%s%s1", entities.InitialReleaseVersion, separator), nil
+	}
+
+	parsed, err := ParseForkVersion(currentVersion, mode)
+	if err != nil {
+		return "", err
+	}
+
+	parsed.Fork++
+	return parsed.String(), nil
+}
+
+// IsForkVersioning reports whether the given mode is one of the fork modes.
+func IsForkVersioning(mode string) bool {
+	return mode == entities.VersioningForkDot || mode == entities.VersioningForkDash
+}
+
+// FindLatestForkVersion scans the changelog lines for the most recent fork
+// version header (skipping the [Unreleased] section) and returns its parsed
+// form. Returns ErrNoForkVersionFound when no compatible header is present.
+func FindLatestForkVersion(lines []string, mode string) (*ForkVersion, error) {
+	for _, line := range lines {
+		match := changelogVersionHeaderRegex.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		header := match[1]
+		if header == "Unreleased" {
+			continue
+		}
+		parsed, err := ParseForkVersion(header, mode)
+		if err != nil {
+			continue
+		}
+		return parsed, nil
+	}
+	return nil, ErrNoForkVersionFound
+}
+
+// ErrNoForkVersionFound is returned when a fork-mode changelog has no usable
+// previous version header.
+var ErrNoForkVersionFound = errors.New("no fork version found in the changelog")
+
+// processForkChangelog rewrites a fork-versioned changelog by moving the
+// content of the [Unreleased] section into a new dated header that uses the
+// next fork version. The function does NOT bump major/minor/patch based on
+// Added/Changed/Fixed -- forks bump only the trailing fork digit.
+//
+// Returns the new version string and the rewritten file content.
+func processForkChangelog(lines []string, mode string) (string, []string, error) {
+	if !IsForkVersioning(mode) {
+		return "", nil, fmt.Errorf("%w: %q is not a fork mode", ErrInvalidForkVersion, mode)
+	}
+
+	current, err := FindLatestForkVersion(lines, mode)
+	currentString := ""
+	switch {
+	case err == nil:
+		currentString = current.String()
+	case errors.Is(err, ErrNoForkVersionFound):
+		// No previous fork version; NextForkVersion will seed an initial value.
+	default:
+		return "", nil, err
+	}
+
+	nextVersion, err := NextForkVersion(currentString, mode)
+	if err != nil {
+		return "", nil, err
+	}
+
+	newContent := rewriteUnreleasedAsForkRelease(lines, nextVersion)
+	return nextVersion, newContent, nil
+}
+
+// rewriteUnreleasedAsForkRelease moves the body of the [Unreleased] section
+// under a freshly minted "## [<version>] - <date>" header and reinstates an
+// empty [Unreleased] section above it. Lines outside the unreleased section
+// are preserved verbatim.
+func rewriteUnreleasedAsForkRelease(lines []string, nextVersion string) []string {
+	unreleasedHeaderIdx := -1
+	nextSectionIdx := len(lines)
+
+	for i, line := range lines {
+		match := changelogVersionHeaderRegex.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		if match[1] == "Unreleased" {
+			unreleasedHeaderIdx = i
+			continue
+		}
+		if unreleasedHeaderIdx != -1 {
+			nextSectionIdx = i
+			break
+		}
+	}
+
+	if unreleasedHeaderIdx == -1 {
+		return lines
+	}
+
+	body := trimBlankEdges(lines[unreleasedHeaderIdx+1 : nextSectionIdx])
+	if len(body) == 0 {
+		return lines
+	}
+
+	releasedHeader := fmt.Sprintf("## [%s] - %s", nextVersion, time.Now().Format("2006-01-02"))
+
+	rebuilt := make([]string, 0, len(lines)+forkRewriteOverhead)
+	rebuilt = append(rebuilt, lines[:unreleasedHeaderIdx]...)
+	rebuilt = append(rebuilt, "## [Unreleased]")
+	rebuilt = append(rebuilt, "")
+	rebuilt = append(rebuilt, releasedHeader)
+	rebuilt = append(rebuilt, "")
+	rebuilt = append(rebuilt, body...)
+	if nextSectionIdx < len(lines) {
+		rebuilt = append(rebuilt, "")
+		rebuilt = append(rebuilt, lines[nextSectionIdx:]...)
+	}
+	return rebuilt
+}
+
+// trimBlankEdges drops leading/trailing empty lines from a slice without
+// mutating the original.
+func trimBlankEdges(lines []string) []string {
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+	end := len(lines)
+	for end > start && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	if start == 0 && end == len(lines) {
+		return lines
+	}
+	return lines[start:end]
+}
+
+func separatorForMode(mode string) (string, error) {
+	switch mode {
+	case entities.VersioningForkDot:
+		return ".", nil
+	case entities.VersioningForkDash:
+		return "-", nil
+	default:
+		return "", fmt.Errorf("%w: %q is not a fork mode", ErrInvalidForkVersion, mode)
+	}
+}
+
+func separatorMatchesMode(separator, mode string) bool {
+	switch mode {
+	case entities.VersioningForkDot:
+		return separator == "."
+	case entities.VersioningForkDash:
+		return separator == "-"
+	case "":
+		return separator == "." || separator == "-"
+	default:
+		return false
+	}
+}

--- a/internal/domain/commands/fork_version_test.go
+++ b/internal/domain/commands/fork_version_test.go
@@ -1,0 +1,357 @@
+//go:build unit
+
+package commands_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autobump/internal/domain/commands"
+	"github.com/rios0rios0/autobump/internal/domain/entities"
+)
+
+func TestParseForkVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should parse 4-segment fork version when mode is fork-dot", func(t *testing.T) {
+		// given
+		input := "3.3.0.16"
+
+		// when
+		parsed, err := commands.ParseForkVersion(input, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, parsed)
+		assert.Equal(t, "3.3.0", parsed.Upstream)
+		assert.Equal(t, ".", parsed.Separator)
+		assert.Equal(t, 16, parsed.Fork)
+	})
+
+	t.Run("should parse dash-separated fork version when mode is fork-dash", func(t *testing.T) {
+		// given
+		input := "1.21.0-9"
+
+		// when
+		parsed, err := commands.ParseForkVersion(input, entities.VersioningForkDash)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0", parsed.Upstream)
+		assert.Equal(t, "-", parsed.Separator)
+		assert.Equal(t, 9, parsed.Fork)
+	})
+
+	t.Run("should accept either separator when mode is empty", func(t *testing.T) {
+		// given
+		dotInput := "v2.5.1.42"
+		dashInput := "v2.5.1-42"
+
+		// when
+		dotParsed, dotErr := commands.ParseForkVersion(dotInput, "")
+		dashParsed, dashErr := commands.ParseForkVersion(dashInput, "")
+
+		// then
+		require.NoError(t, dotErr)
+		require.NoError(t, dashErr)
+		assert.Equal(t, ".", dotParsed.Separator)
+		assert.Equal(t, "-", dashParsed.Separator)
+		assert.Equal(t, 42, dotParsed.Fork)
+		assert.Equal(t, 42, dashParsed.Fork)
+	})
+
+	t.Run("should reject 4-segment version when mode is fork-dash", func(t *testing.T) {
+		// given
+		input := "3.3.0.16"
+
+		// when
+		_, err := commands.ParseForkVersion(input, entities.VersioningForkDash)
+
+		// then
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commands.ErrInvalidForkVersion))
+	})
+
+	t.Run("should reject dash-separated version when mode is fork-dot", func(t *testing.T) {
+		// given
+		input := "1.21.0-9"
+
+		// when
+		_, err := commands.ParseForkVersion(input, entities.VersioningForkDot)
+
+		// then
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commands.ErrInvalidForkVersion))
+	})
+
+	t.Run("should reject malformed version strings", func(t *testing.T) {
+		// given
+		bogusInputs := []string{
+			"",
+			"3.3.0",
+			"3.3.0.",
+			"3.3.0.x",
+			"foo.bar.baz.1",
+			"3.3.0.16-rc1",
+		}
+
+		for _, input := range bogusInputs {
+			// when
+			_, err := commands.ParseForkVersion(input, entities.VersioningForkDot)
+
+			// then
+			require.Errorf(t, err, "input %q should fail to parse", input)
+		}
+	})
+}
+
+func TestNextForkVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should bump only the trailing digit when mode is fork-dot", func(t *testing.T) {
+		// given
+		current := "3.3.0.16"
+
+		// when
+		next, err := commands.NextForkVersion(current, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", next)
+	})
+
+	t.Run("should bump only the trailing digit when mode is fork-dash", func(t *testing.T) {
+		// given
+		current := "1.21.0-9"
+
+		// when
+		next, err := commands.NextForkVersion(current, entities.VersioningForkDash)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0-10", next)
+	})
+
+	t.Run("should seed initial version when current is empty for fork-dot", func(t *testing.T) {
+		// given / when
+		next, err := commands.NextForkVersion("", entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, entities.InitialReleaseVersion+".1", next)
+	})
+
+	t.Run("should seed initial version when current is empty for fork-dash", func(t *testing.T) {
+		// given / when
+		next, err := commands.NextForkVersion("", entities.VersioningForkDash)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, entities.InitialReleaseVersion+"-1", next)
+	})
+
+	t.Run("should fail when mode is not a fork mode", func(t *testing.T) {
+		// given / when
+		_, err := commands.NextForkVersion("1.0.0", entities.VersioningSemver)
+
+		// then
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commands.ErrInvalidForkVersion))
+	})
+}
+
+func TestIsForkVersioning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true for fork-dot and fork-dash", func(t *testing.T) {
+		// given / when / then
+		assert.True(t, commands.IsForkVersioning(entities.VersioningForkDot))
+		assert.True(t, commands.IsForkVersioning(entities.VersioningForkDash))
+	})
+
+	t.Run("should return false for semver and unknown modes", func(t *testing.T) {
+		// given / when / then
+		assert.False(t, commands.IsForkVersioning(entities.VersioningSemver))
+		assert.False(t, commands.IsForkVersioning(""))
+		assert.False(t, commands.IsForkVersioning("calver"))
+	})
+}
+
+func TestFindLatestForkVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should find latest fork-dot version while skipping unreleased", func(t *testing.T) {
+		// given
+		lines := []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+			"",
+			"## [3.3.0.15] - 2026-03-25",
+		}
+
+		// when
+		parsed, err := commands.FindLatestForkVersion(lines, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.16", parsed.String())
+	})
+
+	t.Run("should find latest fork-dash version while skipping unreleased", func(t *testing.T) {
+		// given
+		lines := []string{
+			"## [Unreleased]",
+			"",
+			"## [1.21.0-9] - 2026-01-12",
+			"",
+			"## [1.21.0-8] - 2025-12-29",
+		}
+
+		// when
+		parsed, err := commands.FindLatestForkVersion(lines, entities.VersioningForkDash)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0-9", parsed.String())
+	})
+
+	t.Run("should ignore headers that do not match the requested mode", func(t *testing.T) {
+		// given
+		lines := []string{
+			"## [Unreleased]",
+			"",
+			"## [1.0.0] - 2026-01-01",
+		}
+
+		// when
+		_, err := commands.FindLatestForkVersion(lines, entities.VersioningForkDot)
+
+		// then
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commands.ErrNoForkVersionFound))
+	})
+}
+
+func TestProcessForkChangelog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should rewrite changelog with next fork-dot version", func(t *testing.T) {
+		// given
+		lines := []string{
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"### Fixed",
+			"",
+			"- fixed sidebar selected item background",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+			"",
+			"### Fixed",
+			"",
+			"- raised job timeout",
+		}
+
+		// when
+		nextVersion, newContent, err := commands.ProcessForkChangelog(lines, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", nextVersion)
+		joined := strings.Join(newContent, "\n")
+		assert.Contains(t, joined, "## [Unreleased]")
+		assert.Contains(t, joined, "## [3.3.0.17] - ")
+		assert.Contains(t, joined, "- fixed sidebar selected item background")
+		assert.Contains(t, joined, "## [3.3.0.16] - 2026-04-20")
+		// The previous version must still appear after the new release header.
+		newReleaseIdx := strings.Index(joined, "## [3.3.0.17]")
+		previousIdx := strings.Index(joined, "## [3.3.0.16]")
+		assert.Less(t, newReleaseIdx, previousIdx, "new release header must appear above previous release")
+	})
+
+	t.Run("should rewrite changelog with next fork-dash version", func(t *testing.T) {
+		// given
+		lines := []string{
+			"## [Unreleased]",
+			"",
+			"### Changed",
+			"",
+			"- changed loading spinner color",
+			"",
+			"## [1.21.0-9] - 2026-01-12",
+			"",
+			"### Changed",
+			"",
+			"- changed link color",
+		}
+
+		// when
+		nextVersion, newContent, err := commands.ProcessForkChangelog(lines, entities.VersioningForkDash)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "1.21.0-10", nextVersion)
+		joined := strings.Join(newContent, "\n")
+		assert.Contains(t, joined, "## [1.21.0-10] - ")
+		assert.Contains(t, joined, "- changed loading spinner color")
+	})
+
+	t.Run("should seed initial version when no prior fork version exists", func(t *testing.T) {
+		// given
+		lines := []string{
+			"## [Unreleased]",
+			"",
+			"### Added",
+			"",
+			"- added first feature",
+		}
+
+		// when
+		nextVersion, newContent, err := commands.ProcessForkChangelog(lines, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, entities.InitialReleaseVersion+".1", nextVersion)
+		joined := strings.Join(newContent, "\n")
+		assert.Contains(t, joined, "## ["+nextVersion+"] - ")
+	})
+
+	t.Run("should keep changelog unchanged when unreleased section is empty", func(t *testing.T) {
+		// given
+		lines := []string{
+			"## [Unreleased]",
+			"",
+			"## [3.3.0.16] - 2026-04-20",
+			"",
+			"### Fixed",
+			"",
+			"- raised job timeout",
+		}
+
+		// when
+		nextVersion, newContent, err := commands.ProcessForkChangelog(lines, entities.VersioningForkDot)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.0.17", nextVersion)
+		// Body of unreleased was empty so the file content should not gain a new release header.
+		joined := strings.Join(newContent, "\n")
+		assert.NotContains(t, joined, "## [3.3.0.17]")
+	})
+
+	t.Run("should fail when mode is not a fork mode", func(t *testing.T) {
+		// given / when
+		_, _, err := commands.ProcessForkChangelog([]string{"## [Unreleased]"}, entities.VersioningSemver)
+
+		// then
+		require.Error(t, err)
+	})
+}

--- a/internal/domain/commands/service.go
+++ b/internal/domain/commands/service.go
@@ -50,7 +50,7 @@ var (
 // original globalConfig, but it may update the provided projectConfig.
 // It also merges the changelog_path and versioning fields from the per-project
 // config into the projectConfig when the projectConfig does not already specify
-// one. If no per-project config is found, the original globalConfig is returned
+// them. If no per-project config is found, the original globalConfig is returned
 // unchanged.
 func loadProjectConfigOverrides(
 	globalConfig *entities.GlobalConfig,

--- a/internal/domain/commands/service.go
+++ b/internal/domain/commands/service.go
@@ -48,9 +48,10 @@ var (
 // project directory. If found, it reads the file and merges its languages section
 // into the provided globalConfig, returning a new GlobalConfig without mutating the
 // original globalConfig, but it may update the provided projectConfig.
-// It also merges the changelog_path from the per-project config into the projectConfig
-// when the projectConfig does not already specify one. If no per-project config is
-// found, the original globalConfig is returned unchanged.
+// It also merges the changelog_path and versioning fields from the per-project
+// config into the projectConfig when the projectConfig does not already specify
+// one. If no per-project config is found, the original globalConfig is returned
+// unchanged.
 func loadProjectConfigOverrides(
 	globalConfig *entities.GlobalConfig,
 	projectConfig *entities.ProjectConfig,
@@ -71,6 +72,10 @@ func loadProjectConfigOverrides(
 
 	if projectOverrides.ChangelogPath != "" && projectConfig.ChangelogPath == "" {
 		projectConfig.ChangelogPath = projectOverrides.ChangelogPath
+	}
+
+	if projectOverrides.Versioning != "" && projectConfig.Versioning == "" {
+		projectConfig.Versioning = projectOverrides.Versioning
 	}
 
 	if len(projectOverrides.LanguagesConfig) == 0 {
@@ -448,14 +453,14 @@ func setupRepo(ctx *RepoContext) error {
 }
 
 func createBumpBranch(ctx *RepoContext, changelogPath string) (string, entities.BranchStatus, error) {
-	nextVersion, err := getNextVersion(changelogPath)
+	nextVersion, err := getNextVersionString(ctx.GlobalConfig, ctx.ProjectConfig, changelogPath)
 	if err != nil {
 		return "", entities.BranchCreated, err
 	}
 
-	branchName := "chore/bump-" + nextVersion.String()
+	branchName := "chore/bump-" + nextVersion
 	// Store the version for PR creation even if branch exists
-	ctx.ProjectConfig.NewVersion = nextVersion.String()
+	ctx.ProjectConfig.NewVersion = nextVersion
 
 	branchExists, err := gitInfra.CheckBranchExists(ctx.Repo, branchName)
 	if err != nil {
@@ -476,17 +481,25 @@ func createBumpBranch(ctx *RepoContext, changelogPath string) (string, entities.
 
 func updateChangelogAndVersionFiles(ctx *RepoContext, changelogPath string) error {
 	logger.Infof("Updating changelog file %s", changelogPath)
-	version, err := updateChangelogFile(changelogPath)
+	version, err := updateChangelogFileString(ctx.GlobalConfig, ctx.ProjectConfig, changelogPath)
 	if err != nil {
 		logger.Errorf("No version found in changelog for project at %s\n", ctx.ProjectConfig.Path)
 		return err
 	}
 
-	ctx.ProjectConfig.NewVersion = version.String()
-	logger.Infof("Updating version to %s", ctx.ProjectConfig.NewVersion)
-	err = updateVersion(ctx.GlobalConfig, ctx.ProjectConfig)
-	if err != nil {
-		return err
+	ctx.ProjectConfig.NewVersion = version
+	mode := entities.ResolveVersioning(ctx.GlobalConfig, ctx.ProjectConfig)
+	if IsForkVersioning(mode) {
+		logger.Infof(
+			"Fork versioning mode %q is active; skipping language-specific version file updates for %s",
+			mode, ctx.ProjectConfig.NewVersion,
+		)
+	} else {
+		logger.Infof("Updating version to %s", ctx.ProjectConfig.NewVersion)
+		err = updateVersion(ctx.GlobalConfig, ctx.ProjectConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	return addFilesToWorktree(ctx, changelogPath)
@@ -1174,7 +1187,10 @@ func buildGitforgeRepo(remoteURL string, defaultBranch string) globalEntities.Re
 
 // ---- Changelog I/O wrappers ----
 
-// updateChangelogFile reads the changelog, processes it, and writes it back.
+// updateChangelogFile reads the changelog, processes it with the SemVer
+// pipeline, and writes it back. This is the legacy entry point used by tests.
+// Production callers should prefer updateChangelogFileString to honor the
+// project's versioning mode.
 func updateChangelogFile(changelogPath string) (*semver.Version, error) {
 	lines, err := support.ReadLines(changelogPath)
 	if err != nil {
@@ -1194,7 +1210,40 @@ func updateChangelogFile(changelogPath string) (*semver.Version, error) {
 	return version, nil
 }
 
-// getNextVersion reads the changelog and calculates the next version.
+// updateChangelogFileString rewrites the changelog using the versioning mode
+// resolved from the global/project configuration and returns the next version
+// as a plain string. Fork modes preserve the upstream X.Y.Z and only
+// increment the trailing fork digit; SemVer mode delegates to gitforge.
+func updateChangelogFileString(
+	globalConfig *entities.GlobalConfig,
+	projectConfig *entities.ProjectConfig,
+	changelogPath string,
+) (string, error) {
+	mode := entities.ResolveVersioning(globalConfig, projectConfig)
+	if IsForkVersioning(mode) {
+		lines, err := support.ReadLines(changelogPath)
+		if err != nil {
+			return "", err
+		}
+		nextVersion, newContent, err := processForkChangelog(lines, mode)
+		if err != nil {
+			return "", err
+		}
+		if err = support.WriteLines(changelogPath, newContent); err != nil {
+			return "", err
+		}
+		return nextVersion, nil
+	}
+
+	version, err := updateChangelogFile(changelogPath)
+	if err != nil {
+		return "", err
+	}
+	return version.String(), nil
+}
+
+// getNextVersion reads the changelog and calculates the next SemVer version.
+// Legacy entry point preserved for tests and external callers.
 func getNextVersion(changelogPath string) (*semver.Version, error) {
 	lines, err := support.ReadLines(changelogPath)
 	if err != nil {
@@ -1215,6 +1264,41 @@ func getNextVersion(changelogPath string) (*semver.Version, error) {
 	}
 
 	return version, nil
+}
+
+// getNextVersionString reads the changelog and calculates the next version
+// using the versioning mode resolved from the global/project configuration.
+// The result is returned as a plain string so the caller does not have to
+// know which mode produced it.
+func getNextVersionString(
+	globalConfig *entities.GlobalConfig,
+	projectConfig *entities.ProjectConfig,
+	changelogPath string,
+) (string, error) {
+	mode := entities.ResolveVersioning(globalConfig, projectConfig)
+	if IsForkVersioning(mode) {
+		lines, err := support.ReadLines(changelogPath)
+		if err != nil {
+			return "", err
+		}
+		current, err := FindLatestForkVersion(lines, mode)
+		currentString := ""
+		switch {
+		case err == nil:
+			currentString = current.String()
+		case errors.Is(err, ErrNoForkVersionFound):
+			// No prior fork release yet; NextForkVersion seeds the initial value.
+		default:
+			return "", err
+		}
+		return NextForkVersion(currentString, mode)
+	}
+
+	version, err := getNextVersion(changelogPath)
+	if err != nil {
+		return "", err
+	}
+	return version.String(), nil
 }
 
 // createChangelogIfNotExists create an empty CHANGELOG file if it doesn't exist.

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -19,6 +19,18 @@ import (
 	downloadHelpers "github.com/rios0rios0/gitforge/pkg/config/infrastructure/helpers"
 )
 
+// Versioning modes supported by the bumper.
+//
+// VersioningSemver follows Semantic Versioning (default).
+// VersioningForkDot increments the trailing fork digit in X.Y.Z.N versions.
+// VersioningForkDash increments the trailing fork digit in X.Y.Z-N versions.
+// See the "Forking Technique" guide for the rationale behind the fork modes.
+const (
+	VersioningSemver   = "semver"
+	VersioningForkDot  = "fork-dot"
+	VersioningForkDash = "fork-dash"
+)
+
 // GlobalConfig represents the top-level configuration.
 type GlobalConfig struct {
 	Providers              []configEntities.ProviderConfig `yaml:"providers"`
@@ -27,6 +39,7 @@ type GlobalConfig struct {
 	ExcludeForks           bool                            `yaml:"exclude_forks"`
 	ExcludeArchived        bool                            `yaml:"exclude_archived"`
 	ChangelogPath          string                          `yaml:"changelog_path"`
+	Versioning             string                          `yaml:"versioning"`
 	GpgKeyPath             string                          `yaml:"gpg_key_path"`
 	GpgKeyPassphrase       string                          `yaml:"gpg_key_passphrase"`
 	SSHKeyPath             string                          `yaml:"ssh_key_path"`
@@ -62,6 +75,29 @@ type ProjectConfig struct {
 	ProjectAccessToken string `yaml:"project_access_token"`
 	NewVersion         string `yaml:"new_version"`
 	ChangelogPath      string `yaml:"changelog_path"`
+	Versioning         string `yaml:"versioning"`
+}
+
+// ResolveVersioning returns the effective versioning mode for a project.
+// Project-level setting wins over global, which wins over the semver default.
+// Unknown modes are normalized to the semver default to keep the bumper safe.
+func ResolveVersioning(globalConfig *GlobalConfig, projectConfig *ProjectConfig) string {
+	mode := ""
+	if projectConfig != nil {
+		mode = strings.TrimSpace(projectConfig.Versioning)
+	}
+	if mode == "" && globalConfig != nil {
+		mode = strings.TrimSpace(globalConfig.Versioning)
+	}
+	switch mode {
+	case VersioningForkDot, VersioningForkDash:
+		return mode
+	case "", VersioningSemver:
+		return VersioningSemver
+	default:
+		logger.Warnf("Unknown versioning mode %q, falling back to %q", mode, VersioningSemver)
+		return VersioningSemver
+	}
 }
 
 // DefaultConfigURL is the URL of the default configuration file.

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -369,6 +369,23 @@ func TestReadProjectConfig(t *testing.T) {
 		assert.Contains(t, cfg.LanguagesConfig, "go")
 	})
 
+	t.Run("should read versioning and changelog_path from per-project config", func(t *testing.T) {
+		// given
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".autobump.yaml")
+		content := "versioning: 'fork-dot'\nchangelog_path: 'CHANGELOG_PROPRIETARY.md'\n"
+		require.NoError(t, os.WriteFile(configPath, []byte(content), 0o644))
+
+		// when
+		cfg, err := entities.ReadProjectConfig(configPath)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, entities.VersioningForkDot, cfg.Versioning)
+		assert.Equal(t, "CHANGELOG_PROPRIETARY.md", cfg.ChangelogPath)
+	})
+
 	t.Run("should correctly parse version files with regex patterns", func(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
@@ -921,5 +938,65 @@ func TestFindConfigOnMissing(t *testing.T) {
 
 		// then
 		assert.NotEmpty(t, result)
+	})
+}
+
+func TestResolveVersioning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should default to semver when both configs are nil", func(t *testing.T) {
+		// given / when
+		mode := entities.ResolveVersioning(nil, nil)
+
+		// then
+		assert.Equal(t, entities.VersioningSemver, mode)
+	})
+
+	t.Run("should return project versioning when set", func(t *testing.T) {
+		// given
+		globalConfig := &entities.GlobalConfig{Versioning: entities.VersioningSemver}
+		projectConfig := &entities.ProjectConfig{Versioning: entities.VersioningForkDot}
+
+		// when
+		mode := entities.ResolveVersioning(globalConfig, projectConfig)
+
+		// then
+		assert.Equal(t, entities.VersioningForkDot, mode)
+	})
+
+	t.Run("should fall back to global versioning when project is empty", func(t *testing.T) {
+		// given
+		globalConfig := &entities.GlobalConfig{Versioning: entities.VersioningForkDash}
+		projectConfig := &entities.ProjectConfig{}
+
+		// when
+		mode := entities.ResolveVersioning(globalConfig, projectConfig)
+
+		// then
+		assert.Equal(t, entities.VersioningForkDash, mode)
+	})
+
+	t.Run("should normalize unknown modes to semver", func(t *testing.T) {
+		// given
+		globalConfig := &entities.GlobalConfig{}
+		projectConfig := &entities.ProjectConfig{Versioning: "calver"}
+
+		// when
+		mode := entities.ResolveVersioning(globalConfig, projectConfig)
+
+		// then
+		assert.Equal(t, entities.VersioningSemver, mode)
+	})
+
+	t.Run("should ignore surrounding whitespace", func(t *testing.T) {
+		// given
+		globalConfig := &entities.GlobalConfig{Versioning: " fork-dot  "}
+		projectConfig := &entities.ProjectConfig{}
+
+		// when
+		mode := entities.ResolveVersioning(globalConfig, projectConfig)
+
+		// then
+		assert.Equal(t, entities.VersioningForkDot, mode)
 	})
 }

--- a/test/domain/entitybuilders/global_config_builder.go
+++ b/test/domain/entitybuilders/global_config_builder.go
@@ -16,6 +16,7 @@ type GlobalConfigBuilder struct {
 	excludeForks           bool
 	excludeArchived        bool
 	changelogPath          string
+	versioning             string
 	gpgKeyPath             string
 	gpgKeyPassphrase       string
 	sshKeyPath             string
@@ -65,6 +66,12 @@ func (b *GlobalConfigBuilder) WithLanguagesConfig(
 // WithChangelogPath sets the changelog file path.
 func (b *GlobalConfigBuilder) WithChangelogPath(path string) *GlobalConfigBuilder {
 	b.changelogPath = path
+	return b
+}
+
+// WithVersioning sets the global default versioning mode.
+func (b *GlobalConfigBuilder) WithVersioning(mode string) *GlobalConfigBuilder {
+	b.versioning = mode
 	return b
 }
 
@@ -148,6 +155,7 @@ func (b *GlobalConfigBuilder) BuildGlobalConfig() *entities.GlobalConfig {
 		ExcludeForks:           b.excludeForks,
 		ExcludeArchived:        b.excludeArchived,
 		ChangelogPath:          b.changelogPath,
+		Versioning:             b.versioning,
 		GpgKeyPath:             b.gpgKeyPath,
 		GpgKeyPassphrase:       b.gpgKeyPassphrase,
 		SSHKeyPath:             b.sshKeyPath,
@@ -169,6 +177,7 @@ func (b *GlobalConfigBuilder) Reset() testkit.Builder {
 	b.excludeForks = false
 	b.excludeArchived = false
 	b.changelogPath = ""
+	b.versioning = ""
 	b.gpgKeyPath = ""
 	b.gpgKeyPassphrase = ""
 	b.sshKeyPath = ""
@@ -208,6 +217,7 @@ func (b *GlobalConfigBuilder) Clone() testkit.Builder {
 		excludeForks:           b.excludeForks,
 		excludeArchived:        b.excludeArchived,
 		changelogPath:          b.changelogPath,
+		versioning:             b.versioning,
 		gpgKeyPath:             b.gpgKeyPath,
 		gpgKeyPassphrase:       b.gpgKeyPassphrase,
 		sshKeyPath:             b.sshKeyPath,

--- a/test/domain/entitybuilders/project_config_builder.go
+++ b/test/domain/entitybuilders/project_config_builder.go
@@ -16,6 +16,7 @@ type ProjectConfigBuilder struct {
 	projectAccessToken string
 	newVersion         string
 	changelogPath      string
+	versioning         string
 }
 
 // NewProjectConfigBuilder creates a new ProjectConfig builder with sensible defaults.
@@ -28,6 +29,7 @@ func NewProjectConfigBuilder() *ProjectConfigBuilder {
 		projectAccessToken: "",
 		newVersion:         "",
 		changelogPath:      "",
+		versioning:         "",
 	}
 }
 
@@ -67,6 +69,12 @@ func (b *ProjectConfigBuilder) WithChangelogPath(path string) *ProjectConfigBuil
 	return b
 }
 
+// WithVersioning sets the versioning mode (semver, fork-dot, fork-dash).
+func (b *ProjectConfigBuilder) WithVersioning(mode string) *ProjectConfigBuilder {
+	b.versioning = mode
+	return b
+}
+
 // Build creates the ProjectConfig (satisfies testkit.Builder interface).
 func (b *ProjectConfigBuilder) Build() interface{} {
 	return b.BuildProjectConfig()
@@ -81,6 +89,7 @@ func (b *ProjectConfigBuilder) BuildProjectConfig() *entities.ProjectConfig {
 		ProjectAccessToken: b.projectAccessToken,
 		NewVersion:         b.newVersion,
 		ChangelogPath:      b.changelogPath,
+		Versioning:         b.versioning,
 	}
 }
 
@@ -93,6 +102,7 @@ func (b *ProjectConfigBuilder) Reset() testkit.Builder {
 	b.projectAccessToken = ""
 	b.newVersion = ""
 	b.changelogPath = ""
+	b.versioning = ""
 	return b
 }
 
@@ -106,5 +116,6 @@ func (b *ProjectConfigBuilder) Clone() testkit.Builder {
 		projectAccessToken: b.projectAccessToken,
 		newVersion:         b.newVersion,
 		changelogPath:      b.changelogPath,
+		versioning:         b.versioning,
 	}
 }


### PR DESCRIPTION
## Summary

Adds first-class support for forked repositories that follow the [Forking Technique](https://github.com/rios0rios0/guide/wiki/Forking-Technique), where the upstream `X.Y.Z` segment is preserved and only a trailing fork digit (`N`) is bumped per release.

- New `versioning` config key (`semver` | `fork-dot` | `fork-dash`), recognized at both global and per-project levels.
- Per-project `.autobump.yaml` now propagates `versioning` and `changelog_path` (via the existing `FindProjectConfigFile` flow) so a fork can opt in without touching the global config.
- New fork-version parser/bumper preserves the upstream `X.Y.Z` and increments only the fork digit (`3.3.0.16` → `3.3.0.17`, `1.21.0-9` → `1.21.0-10`).
- Fork modes skip language-specific version-file rewrites; forks generally maintain those manually or via separate pipelines.

## Motivation

Forks like `opensearch-dashboards` and `oui` track proprietary changes in `CHANGELOG_PROPRIETARY.md` (the community `CHANGELOG.md` is overwritten on each upstream rebase) and use fork-style versions (`3.3.0.16`, `1.21.0-9`) that are incompatible with the previous `Masterminds/semver` parser. Without this change, AutoBump would either fail to parse the version (`fork-dot`) or jump to a fresh major/minor (`fork-dash`).

## Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`make lint`, `make test`, `make sast`)
- [x] Are the tests passing?

## Test plan

- [x] `make lint` -- clean (0 issues)
- [x] `make test` -- all unit/integration suites pass
- [x] `make sast` -- only pre-existing findings (unrelated to this PR)
- [x] New BDD unit tests cover:
  - [x] `ParseForkVersion` happy paths (4-segment, dash) and rejection of malformed input
  - [x] `NextForkVersion` bumping for both modes plus initial-version seeding
  - [x] `IsForkVersioning` truth table
  - [x] `FindLatestForkVersion` walks past `[Unreleased]` and ignores non-matching headers
  - [x] `processForkChangelog` rewrites the changelog with both fork forms and is a no-op when `[Unreleased]` is empty
  - [x] `getNextVersionString` / `updateChangelogFileString` dispatch on the resolved versioning mode
  - [x] `loadProjectConfigOverrides` propagates `versioning` (and respects project-over-global precedence)
  - [x] `ReadProjectConfig` recognizes the new `versioning` key
  - [x] `ResolveVersioning` precedence and unknown-mode normalization
- [ ] Manual smoke against an actual fork repo (Azure DevOps `opensearch-dashboards` and `oui`) -- to be run after merge

## Example usage

```yaml
# ~/.config/autobump.yaml
projects:
  - path: '~/Development/dev.azure.com/MyOrg/forks/opensearch-dashboards'
    changelog_path: 'CHANGELOG_PROPRIETARY.md'
    versioning: 'fork-dot'

  - path: '~/Development/dev.azure.com/MyOrg/forks/oui'
    changelog_path: 'CHANGELOG_PROPRIETARY.md'
    versioning: 'fork-dash'
```

Or, equivalently, in the fork's root:

```yaml
# .autobump.yaml inside the fork
changelog_path: 'CHANGELOG_PROPRIETARY.md'
versioning: 'fork-dot'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)