### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,8 @@ autobump/
 │   │   ├── commands/
 │   │   │   ├── service.go               # Use cases: ProcessRepo, IterateProjects,
 │   │   │   │                            #   DiscoverAndProcess, DetectProjectLanguage
+│   │   │   ├── fork_version.go          # Fork versioning: fork-dot/fork-dash modes,
+│   │   │   │                            #   fork-aware changelog bumping
 │   │   │   ├── self_update.go           # SelfUpdate interface and SelfUpdateRunnerFunc type
 │   │   │   ├── self_update_command.go   # SelfUpdateCommand implementation (via cliforge)
 │   │   │   ├── version.go              # Version interface
@@ -109,7 +111,7 @@ autobump/
 │   ├── autobump.yaml                    # Default configuration template
 │   └── CHANGELOG.template.md           # Default CHANGELOG template
 ├── Makefile                             # Build: build, debug, build-musl, run, install
-├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.26.2)
+├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.26.3)
 └── .github/
     └── workflows/default.yaml           # CI/CD pipeline (go-binary reusable workflow)
 ```
@@ -211,12 +213,10 @@ The tool auto-detects and supports:
 
 ### Test Files
 
-| File | Tests |
-|---|---|
-| `internal/domain/commands/service_test.go` | Language detection, repo processing, discover/batch logic |
-| `internal/domain/commands/export_test.go` | Exports unexported command functions for white-box testing |
-| `internal/domain/entities/export_test.go` | Exports unexported changelog/dedup functions for white-box testing |
-| `test/domain/entitybuilders/repository_builder.go` | Test builder for `Repository` entities |
+Tests are co-located with source files using `_test.go` suffix. Key patterns:
+- `service_test.go`, `fork_version_test.go`, `process_repo_test.go`, etc. — use-case tests across `commands/`
+- `export_test.go` — in each package, exposes unexported functions for white-box testing
+- `test/domain/entitybuilders/` — testkit-based builders for `GlobalConfig`, `ProjectConfig`, `ProviderConfig`, `Repository`
 
 ### Running Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+- refreshed `CLAUDE.md` to document fork versioning modes and per-project `.autobump.yaml` overrides
+- refreshed `.github/copilot-instructions.md` to correct Go version, add `fork_version.go` to repo structure, and update test files section
 
 ## [2.32.3] - 2026-05-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,7 @@ Three-stage fallback in `DetectProjectLanguage`:
 ## Configuration
 
 Config file search order: `.` → `.config/` → `configs/` → `~/` → `~/.config/`. Falls back to downloading default from GitHub. Token values support inline strings, `${ENV_VAR}` expansion, and file paths. SSH push auth is configured via `ssh_key_path`, `ssh_key_passphrase`, and `ssh_auth_sock` fields; common SSH agent sockets (1Password, standard `ssh-agent`) are auto-detected when not explicitly set.
+
+Versioning modes: `semver` (default), `fork-dot`, `fork-dash`. Fork modes increment only the trailing fork digit (e.g. `3.3.0.16` → `3.3.0.17`) and skip language-specific version-file rewrites. See `internal/domain/commands/fork_version.go`.
+
+Per-project `.autobump.yaml` files can override `changelog_path`, `versioning`, and `languages` fields. `loadProjectConfigOverrides` in `service.go` merges these into the resolved config.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.