### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` to correct the version-file list (Go and Terraform rely on git tags, Python bumps `__init__.py`; `go.mod`/`pyproject.toml` are detection markers, not bumped files)
+
 ## [2.32.7] - 2026-05-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-AutoBump is a Go CLI tool that automates the release process: it reads `CHANGELOG.md`, calculates the next semantic version, updates language-specific version files (`package.json`, `build.gradle`/`pom.xml`, `__init__.py`, `*.csproj`, `Chart.yaml`; Go and Terraform carry no version file and rely on git tags), commits, pushes, and creates PRs/MRs on GitHub, GitLab, or Azure DevOps.
+AutoBump is a Go CLI tool that automates the release process: it reads `CHANGELOG.md`, calculates the next semantic version, updates the language-specific version files configured in `configs/autobump.yaml` (TypeScript `package.json`; Java `build.gradle`, `lib/build.gradle`, `pom.xml`, `src/main/resources/application.yaml`; Python `{project_name}/__init__.py`; C# `*/*.csproj`, `*/*.vdproj`; Helm `Chart.yaml`; Go and Terraform carry no version file and rely on git tags), commits, pushes, and creates PRs/MRs on GitHub, GitLab, or Azure DevOps. The list above mirrors the default config — treat `configs/autobump.yaml` as the source of truth.
 
 ## Build & Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-AutoBump is a Go CLI tool that automates the release process: it reads `CHANGELOG.md`, calculates the next semantic version, updates language-specific version files (go.mod, package.json, pyproject.toml, build.gradle, *.csproj), commits, pushes, and creates PRs/MRs on GitHub, GitLab, or Azure DevOps.
+AutoBump is a Go CLI tool that automates the release process: it reads `CHANGELOG.md`, calculates the next semantic version, updates language-specific version files (`package.json`, `build.gradle`/`pom.xml`, `__init__.py`, `*.csproj`, `Chart.yaml`; Go and Terraform carry no version file and rely on git tags), commits, pushes, and creates PRs/MRs on GitHub, GitLab, or Azure DevOps.
 
 ## Build & Development Commands
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.