### PR TITLE
fix(signing): read `gpg.ssh.program` from the `[gpg "ssh"]` subsection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Fixed
+
+- fixed SSH commit signing ignoring a configured `gpg.ssh.program` (such as 1Password's `op-ssh-sign-wsl`): the value was read as a flat `gpg.ssh` section instead of the `[gpg "ssh"]` subsection, so signing always fell back to `ssh-keygen` and failed where the private key is only reachable through the configured signer
+
 ## [2.32.9] - 2026-06-09
 
 ### Changed

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -13,6 +13,9 @@ func FilterRepositories(
 // CommitChanges exports the commitChanges function for testing.
 var CommitChanges = commitChanges //nolint:gochecknoglobals // test export
 
+// ResolveSSHProgram exports resolveSSHProgram for testing.
+var ResolveSSHProgram = resolveSSHProgram //nolint:gochecknoglobals // test export
+
 // ResolveConfigKey exports resolveConfigKey for testing.
 var ResolveConfigKey = resolveConfigKey //nolint:gochecknoglobals // test export
 

--- a/internal/domain/commands/service.go
+++ b/internal/domain/commands/service.go
@@ -370,7 +370,7 @@ func commitAndPushInitialChangelog(ctx *RepoContext, changelogPath string) error
 	gpgSign := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "commit", "gpgsign")
 	gpgFormat := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "gpg", "format")
 	signingKey := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "signingkey")
-	sshProgram := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "gpg.ssh", "program")
+	sshProgram := resolveSSHProgram(cfg, ctx.GlobalGitConfig)
 
 	name := ctx.GlobalGitConfig.Raw.Section("user").Option("name")
 	email := ctx.GlobalGitConfig.Raw.Section("user").Option("email")
@@ -564,6 +564,17 @@ func commitAndPushChanges(ctx *RepoContext, branchName string) error {
 	return nil
 }
 
+// resolveSSHProgram reads gpg.ssh.program from the local or global git config.
+// Git stores this value as the "program" option of the "ssh" subsection under the
+// "gpg" section ([gpg "ssh"] program = ...), so it must be read with the
+// subsection-aware helper. A flat section lookup for "gpg.ssh" never matches the
+// subsection and silently returns "", which makes the SSH signer fall back to
+// ssh-keygen instead of honoring a configured signer such as 1Password's
+// op-ssh-sign-wsl.
+func resolveSSHProgram(cfg, globalCfg *gitconfig.Config) string {
+	return gitHelpers.GetSubsectionOptionFromConfig(cfg, globalCfg, "gpg", "ssh", "program")
+}
+
 // commitChanges commits the staged changes with optional GPG or SSH signing.
 func commitChanges(ctx *RepoContext) (plumbing.Hash, error) {
 	cfg, err := ctx.Repo.Config()
@@ -579,7 +590,7 @@ func commitChanges(ctx *RepoContext) (plumbing.Hash, error) {
 	email := ctx.GlobalGitConfig.Raw.Section("user").Option("email")
 	commitMessage := "chore(bump): bumped version to " + ctx.ProjectConfig.NewVersion
 
-	sshProgram := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "gpg.ssh", "program")
+	sshProgram := resolveSSHProgram(cfg, ctx.GlobalGitConfig)
 
 	signer, err := signingInfra.ResolveSignerFromGitConfig(
 		gpgSign, gpgFormat, signingKey,

--- a/internal/domain/commands/service_test.go
+++ b/internal/domain/commands/service_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1224,5 +1225,59 @@ func TestFilterRepositories(t *testing.T) {
 
 		// then
 		assert.Empty(t, result)
+	})
+}
+
+// TestResolveSSHProgram locks in that gpg.ssh.program is read from the "ssh"
+// subsection of the "gpg" section. A flat "gpg.ssh" section lookup silently
+// returns "" (the original bug), which made the SSH signer fall back to
+// ssh-keygen instead of a configured signer such as op-ssh-sign-wsl.
+func TestResolveSSHProgram(t *testing.T) {
+	t.Parallel()
+
+	newCfg := func() *gitconfig.Config {
+		cfg := &gitconfig.Config{}
+		cfg.Raw = gitconfig.NewConfig().Raw
+		return cfg
+	}
+
+	t.Run("should read gpg.ssh.program from the global config subsection", func(t *testing.T) {
+		// given
+		local := newCfg()
+		global := newCfg()
+		global.Raw.Section("gpg").Subsection("ssh").
+			SetOption("program", "/opt/1Password/op-ssh-sign-wsl")
+
+		// when
+		program := commands.ResolveSSHProgram(local, global)
+
+		// then
+		assert.Equal(t, "/opt/1Password/op-ssh-sign-wsl", program)
+	})
+
+	t.Run("should prefer the local config over the global config", func(t *testing.T) {
+		// given
+		local := newCfg()
+		local.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/local/signer")
+		global := newCfg()
+		global.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/global/signer")
+
+		// when
+		program := commands.ResolveSSHProgram(local, global)
+
+		// then
+		assert.Equal(t, "/local/signer", program)
+	})
+
+	t.Run("should return empty when gpg.ssh.program is not configured", func(t *testing.T) {
+		// given
+		local := newCfg()
+		global := newCfg()
+
+		// when
+		program := commands.ResolveSSHProgram(local, global)
+
+		// then
+		assert.Empty(t, program)
 	})
 }


### PR DESCRIPTION
## Summary

SSH commit signing ignored a configured `gpg.ssh.program` and always fell back to `ssh-keygen`. In environments where the signing key is only reachable through the configured signer — e.g. **1Password's `op-ssh-sign-wsl` under WSL2** — `autobump` left an **unsigned** commit and exited non-zero before pushing, even though `git commit -S` signed fine with the same key.

## Root cause

`autobump` read the signer program with a **flat** section lookup:

```go
// internal/domain/commands/service.go (before)
sshProgram := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "gpg.ssh", "program")
```

`GetOptionFromConfig` resolves `cfg.Raw.Section("gpg.ssh").Option("program")`, but git stores the value as section `gpg`, **subsection** `ssh` (`[gpg "ssh"] program = …`). A flat `gpg.ssh` section never matches the subsection, so `sshProgram` resolved to `""` and `SignSSHCommit` defaulted to `ssh-keygen`.

Proven against a real `~/.gitconfig` that has `[gpg "ssh"] program = …/op-ssh-sign-wsl`:

```
GetOptionFromConfig("gpg.ssh","program")             = ""        ← what autobump read
GetSubsectionOptionFromConfig("gpg","ssh","program") = "…/op-ssh-sign-wsl"
```

The `-U` flag and `SSH_AUTH_SOCK` propagation in `gitforge`'s signer were already correct — the only defect was reading the program from the wrong place, so the signer never switched away from `ssh-keygen` (which has no usable key when the agent is 1Password-only).

## Fix

Use the subsection-aware helper `gitforge` already ships, via a small `resolveSSHProgram` helper, at both call sites (`commitChanges` and `commitAndPushInitialChangelog`):

```go
func resolveSSHProgram(cfg, globalCfg *gitconfig.Config) string {
	return gitHelpers.GetSubsectionOptionFromConfig(cfg, globalCfg, "gpg", "ssh", "program")
}
```

## Verification

`go build ./...`, `go vet`, `go test -tags=unit ./...` (incl. new `TestResolveSSHProgram`), and `make lint` (0 issues) all pass.

End-to-end, the **patched** binary on a terraform module now logs:

```
Signing commit with SSH program: /mnt/c/Program Files/1Password/app/8/op-ssh-sign-wsl   (was: ssh-keygen)
Successfully signed commit with SSH key
```

and the resulting bump commit verifies:

```
Good "git" signature … with ED25519 key SHA256:C193jo…
```

The commit on this PR is itself signed through the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
