### PR TITLE
fix: honor local Git identity and unblock releases

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,3 @@
 README.md:gitlab-pat:143
 README.md:gitlab_personal_access_token:143
+42a90f886a27f99560a300d024b524b154f7096d:README.md:gitlab-pat:113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the commit author identity in `autobump local` (and `autobump .`): `user.name` and `user.email` are now read from the repository's local Git config first, falling back to the global `~/.gitconfig`, instead of always using the global identity
+- fixed the release pipeline being blocked by a Gitleaks false positive on an example GitLab token in the `README.md` Git history, which had prevented new releases (and therefore `self-update`) from being published
+
 ## [2.32.10] - 2026-06-18
 
 ### Changed

--- a/internal/domain/commands/git_operations_test.go
+++ b/internal/domain/commands/git_operations_test.go
@@ -332,36 +332,45 @@ func TestUpdateChangelogAndVersionFiles(t *testing.T) {
 	})
 }
 
+// buildCommitCtx stages a file in repo and returns a RepoContext whose global Git
+// config carries the given identity. Shared by the TestCommitChanges sub-tests.
+func buildCommitCtx(
+	t *testing.T, repo *git.Repository, repoPath, globalName, globalEmail string,
+) *commands.RepoContext {
+	t.Helper()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	testFile := filepath.Join(repoPath, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0o644))
+	_, err = wt.Add("test.txt")
+	require.NoError(t, err)
+
+	// Minimal git config without signing to avoid SSH agent issues
+	globalGitConfig := &config.Config{}
+	globalGitConfig.Raw = config.NewConfig().Raw
+	globalGitConfig.Raw.Section("user").SetOption("name", globalName)
+	globalGitConfig.Raw.Section("user").SetOption("email", globalEmail)
+
+	return &commands.RepoContext{
+		Repo:            repo,
+		Worktree:        wt,
+		GlobalGitConfig: globalGitConfig,
+		GlobalConfig:    entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig(),
+		ProjectConfig: entitybuilders.NewProjectConfigBuilder().
+			WithNewVersion("1.0.0").
+			BuildProjectConfig(),
+	}
+}
+
 func TestCommitChanges(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should create a commit when changes are staged", func(t *testing.T) {
 		// given
 		repoPath, repo := createTestRepo(t)
-		wt, err := repo.Worktree()
-		require.NoError(t, err)
-
-		// Create and stage a file
-		testFile := filepath.Join(repoPath, "test.txt")
-		require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0o644))
-		_, err = wt.Add("test.txt")
-		require.NoError(t, err)
-
-		// Use a minimal git config without signing to avoid SSH agent issues
-		globalGitConfig := &config.Config{}
-		globalGitConfig.Raw = config.NewConfig().Raw
-		globalGitConfig.Raw.Section("user").SetOption("name", "Test User")
-		globalGitConfig.Raw.Section("user").SetOption("email", "test@test.com")
-
-		ctx := &commands.RepoContext{
-			Repo:            repo,
-			Worktree:        wt,
-			GlobalGitConfig: globalGitConfig,
-			GlobalConfig:    entitybuilders.NewGlobalConfigBuilder().BuildGlobalConfig(),
-			ProjectConfig: entitybuilders.NewProjectConfigBuilder().
-				WithNewVersion("1.0.0").
-				BuildProjectConfig(),
-		}
+		ctx := buildCommitCtx(t, repo, repoPath, "Test User", "test@test.com")
 
 		// when
 		hash, err := commands.CommitChanges(ctx)
@@ -369,11 +378,34 @@ func TestCommitChanges(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.NotEqual(t, plumbing.ZeroHash, hash)
-
-		// verify commit
 		commit, commitErr := repo.CommitObject(hash)
 		require.NoError(t, commitErr)
 		assert.Contains(t, commit.Message, "chore(bump): bumped version to 1.0.0")
+	})
+
+	t.Run("should use the local repo identity over the global one when set", func(t *testing.T) {
+		// given
+		repoPath, repo := createTestRepo(t)
+
+		// Set a repo-local identity that differs from the global one
+		localCfg, err := repo.Config()
+		require.NoError(t, err)
+		localCfg.Raw.Section("user").SetOption("name", "Local User")
+		localCfg.Raw.Section("user").SetOption("email", "local@repo.com")
+		require.NoError(t, repo.Storer.SetConfig(localCfg))
+
+		// Global identity must NOT be used when a local one is present
+		ctx := buildCommitCtx(t, repo, repoPath, "Global User", "global@global.com")
+
+		// when
+		hash, err := commands.CommitChanges(ctx)
+
+		// then
+		require.NoError(t, err)
+		commit, commitErr := repo.CommitObject(hash)
+		require.NoError(t, commitErr)
+		assert.Equal(t, "Local User", commit.Author.Name)
+		assert.Equal(t, "local@repo.com", commit.Author.Email)
 	})
 }
 

--- a/internal/domain/commands/service.go
+++ b/internal/domain/commands/service.go
@@ -372,8 +372,8 @@ func commitAndPushInitialChangelog(ctx *RepoContext, changelogPath string) error
 	signingKey := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "signingkey")
 	sshProgram := resolveSSHProgram(cfg, ctx.GlobalGitConfig)
 
-	name := ctx.GlobalGitConfig.Raw.Section("user").Option("name")
-	email := ctx.GlobalGitConfig.Raw.Section("user").Option("email")
+	name := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "name")
+	email := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "email")
 
 	signer, err := signingInfra.ResolveSignerFromGitConfig(
 		gpgSign, gpgFormat, signingKey,
@@ -586,8 +586,8 @@ func commitChanges(ctx *RepoContext) (plumbing.Hash, error) {
 	gpgFormat := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "gpg", "format")
 	signingKey := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "signingkey")
 
-	name := ctx.GlobalGitConfig.Raw.Section("user").Option("name")
-	email := ctx.GlobalGitConfig.Raw.Section("user").Option("email")
+	name := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "name")
+	email := gitHelpers.GetOptionFromConfig(cfg, ctx.GlobalGitConfig, "user", "email")
 	commitMessage := "chore(bump): bumped version to " + ctx.ProjectConfig.NewVersion
 
 	sshProgram := resolveSSHProgram(cfg, ctx.GlobalGitConfig)


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

---

Fixes two issues reported when running AutoBump locally.

## 1. `autobump .` used the wrong commit identity

`commitChanges` and `commitAndPushInitialChangelog` read `user.name` / `user.email` directly from the **global** `~/.gitconfig`, ignoring the repository's local `.git/config`. The signing options right next to them already used `gitHelpers.GetOptionFromConfig`, which prefers the local config and falls back to global — so the identity reads simply bypassed that helper.

**Fix:** route `name`/`email` through `GetOptionFromConfig` (local-first, global fallback).

- No-op for repos that rely on the global identity (local section is empty → falls back to global).
- In `run`/discover mode the cloned repo has no local identity, so it still falls back to global — unchanged.
- The push-auth `username` is intentionally left global, since it pairs with the account-level token.
- Added a unit test asserting the local identity wins over the global one.

## 2. `self-update` reported "already up to date" forever

The self-update command works; the real cause is that **releases stopped publishing after `2.32.6`**. The `sast:gitleaks` job fails on `main` on a **false positive** — an example token (`glpat-PROJECT-SPECIFIC-TOKEN`) in the `README.md` **git history** (commit `42a90f8`). The existing `.gitleaksignore` entry referenced a stale line (`143`) in the wrong (commit-less) format, so the finding leaked through and the failing job skipped the release stage.

**Fix:** add the exact historical fingerprint `42a90f886a27...:README.md:gitlab-pat:113` from the CI report to `.gitleaksignore`. (The current README uses the short `glpat-TOKEN` placeholder, which does not match the rule, so no recurrence.)

## Validation

- `make lint` → 0 issues
- `go test -tags unit ./...` → all pass (incl. the new local-identity test)

> Note: commits are unsigned because the 1Password SSH signer could not be reached non-interactively from the automation shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)