### PR TITLE
fix(version): derived the build version from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `autobump version` and `autobump self-update` reporting a stale version when Git tags lag behind `CHANGELOG.md` (for example, after a release pipeline was interrupted and the tag was never published): the build version is now derived from the latest versioned heading in `CHANGELOG.md` — AutoBump's own release source of truth — falling back to the latest Git tag and then `dev`
+
 ## [2.32.11] - 2026-06-22
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@ SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 -include $(SCRIPTS_DIR)/makefiles/common.mk
 -include $(SCRIPTS_DIR)/makefiles/golang.mk
 
-VERSION ?= $(shell { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
+# The build version comes from the latest versioned heading in CHANGELOG.md,
+# which is AutoBump's own source of truth for releases. Git tags can lag behind
+# the CHANGELOG when a release pipeline is interrupted, so a tag is only used as
+# a fallback (and finally "dev"). An explicit VERSION from the environment/CLI
+# always wins thanks to ?=.
+VERSION ?= $(shell { grep -oE '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'; } || { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
 LDFLAGS := -X main.version=$(VERSION)
 
 .PHONY: debug build build-musl install run

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 # the CHANGELOG when a release pipeline is interrupted, so a tag is only used as
 # a fallback (and finally "dev"). An explicit VERSION from the environment/CLI
 # always wins thanks to ?=.
-VERSION ?= $(shell { grep -oE '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'; } || { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
+VERSION ?= $(shell { grep -m1 -oE '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'; } || { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
 LDFLAGS := -X main.version=$(VERSION)
 
 .PHONY: debug build build-musl install run


### PR DESCRIPTION
## Summary

`autobump version` and `autobump self-update` reported a **stale version**. For example, after `CHANGELOG.md` had already advanced to `2.32.11`, a freshly built binary still reported `2.32.6`, and `self-update` printed `Current autobump version: 2.32.6`.

### Root cause

The build version was derived from the latest Git tag (`git describe --tags`). Git tags can fall behind `CHANGELOG.md` whenever a release pipeline is interrupted and the tag is never published — so the binary advertised the last *tagged* version rather than the actual current one.

### Fix

The version is now read from the latest versioned heading in `CHANGELOG.md` — AutoBump's own source of truth for releases — with a fallback chain:

1. latest `## [X.Y.Z]` heading in `CHANGELOG.md`
2. latest Git tag (`git describe --tags`)
3. `dev`

An explicit `VERSION` passed from the environment/CLI still wins (`?=`), so CI can override when needed. The released binary (built by `goreleaser` from the tag) is unaffected.

### Verification

| | before | after |
|---|---|---|
| `autobump version` | `2.32.6` | `2.32.11` |
| `autobump self-update` "Current version" | `2.32.6` | `2.32.11` |

Unit tests pass.