### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Note: The CI/CD pipeline automatically uses these scripts via the reusable workf
 
 ## Architecture
 
-The project follows **Clean Architecture** with dependencies always pointing inward toward the domain layer. Dependency injection is handled by [go.uber.org/dig](https://github.com/uber-go/dig). Provider and Git forge abstractions are sourced from the [rios0rios0/gitforge](https://github.com/rios0rios0/gitforge) library. CLI utilities (self-update, version commands, startup update checks) come from [rios0rios0/cliforge](https://github.com/rios0rios0/cliforge).
+The project follows **Clean Architecture** with dependencies always pointing inward toward the domain layer. Dependency injection is handled by [go.uber.org/dig](https://github.com/uber-go/dig). Provider and Git forge abstractions are sourced from the [rios0rios0/gitforge](https://github.com/rios0rios0/gitforge) library. CLI utilities (self-update, version commands, startup update checks) come from [rios0rios0/cliforge](https://github.com/rios0rios0/cliforge). Language detection is driven by [rios0rios0/langforge](https://github.com/rios0rios0/langforge) (marker-file registry + classifier).
 
 ### Repository Structure
 
@@ -133,7 +133,7 @@ autobump/
 - **Adapter pattern**: `ForgeProvider`/`LocalGitAuthProvider` interfaces (from gitforge) with GitHub/GitLab/Azure DevOps implementations
 - **Registry pattern**: `ProviderRegistry` wraps gitforge's registry for adapter and discoverer lookup
 - **Factory pattern**: Discoverer and provider creation from token string via registered factories
-- **Strategy pattern**: Language detection via file-pattern matching (special patterns and extensions)
+- **Strategy pattern**: Language detection is a three-stage fallback in `DetectProjectLanguage` — (1) langforge registry marker files, (2) config-driven special patterns, (3) langforge extension classifier
 - **Controller pattern**: Each CLI subcommand is a `Controller` implementing `GetBind()` and `Execute()`
 
 ### Key Domain Interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document `langforge` as the primary language-detection dependency and correct the three-stage `DetectProjectLanguage` fallback
+
 ## [2.32.14] - 2026-07-03
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.