### PR TITLE
fix(gitleaks): allowlisted the token placeholder on both detection passes

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,26 @@
-README.md:gitlab-pat:143
-README.md:gitlab_personal_access_token:143
+# Gitleaks false-positive allowlist.
+#
+# Every entry is a full fingerprint: <commit>:<file>:<rule-id>:<line>. The CI scan
+# runs `gitleaks detect --log-opts HEAD`, which walks every commit reachable from
+# HEAD, so a finding keeps being reported even after the offending file is rewritten
+# at the tip. An allowlist entry is the only way to clear it.
+#
+# The pipeline scans twice, and a single match has to be allowlisted once per pass,
+# because the fingerprint embeds the rule id and each pass names the rule
+# differently:
+#
+#   * pass 1 -- the gitleaks default ruleset ....... "gitlab-pat"
+#   * pass 2 -- the GitLab-customised ruleset that
+#               the pipelines repository supplies ... "gitlab_personal_access_token"
+#
+# Allowlisting only one of the two leaves the other pass red, which is what used to
+# fail every `main` build here.
+#
+# 2026-07-13 -- both entries below are the same documentation placeholder: the
+# batch-mode example in README.md set `project_access_token` to a dummy value that
+# happened to carry the real GitLab prefix followed by the number of characters the
+# rules count, which is all they look for. No credential was ever committed. The
+# README no longer spells the placeholder that way, but the scan still walks the
+# commit that did.
 42a90f886a27f99560a300d024b524b154f7096d:README.md:gitlab-pat:113
+42a90f886a27f99560a300d024b524b154f7096d:README.md:gitlab_personal_access_token:113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the `sast:gitleaks` pipeline job failing on every `main` build by allowlisting the GitLab token
+  placeholder documented in `README.md` for both detection passes: it was suppressed only under the rule
+  id used by the default ruleset, while the second pass reports the same match under a different rule id
+
 ## [2.33.0] - 2026-07-13
 
 ### Added


### PR DESCRIPTION
## Problem

The `sast:gitleaks` job fails on every `main` build ([run #624](https://github.com/rios0rios0/autobump/actions/runs/29264450958)). It is the only red job, and because the `20-security` stage is a dependency it also blocks `test:all`, `report:sonarqube` and `release` from running on `main`.

The single finding is the **token placeholder in the `README.md` batch-mode example** (`project_access_token`, in the commit that introduced it). It is a dummy value that happens to carry the real GitLab prefix followed by the exact number of characters the rule counts — which is all the rule looks for. **No credential was ever committed.**

## Root cause

The repository already had a `.gitleaksignore` for this, so why was it still red?

The pipeline scans **twice** — pass 1 with the gitleaks default ruleset, pass 2 with the GitLab-customised ruleset from the pipelines repository — and **the two passes name the same rule differently**. A fingerprint embeds the rule id, so one match needs one entry *per pass*:

| Pass | Ruleset | Rule id | Was allowlisted? |
|---|---|---|---|
| 1 | gitleaks defaults | `gitlab-pat` | ✅ yes |
| 2 | GitLab-customised | `gitlab_personal_access_token` | ❌ **no** → job failed here |

The remaining two entries in the file were of the form `README.md:<rule>:143` — no commit hash. Gitleaks matches on the full `<commit>:<file>:<rule-id>:<line>` fingerprint for a git-history scan and silently ignored them, so they never suppressed anything.

## Fix

Added the missing pass-2 fingerprint, kept the working pass-1 one, and dropped the two entries that never had any effect. The file now documents the two-pass/two-rule-id trap so the next person does not re-remove the "duplicate"-looking line.

**Why an allowlist and not a source fix:** the scan runs `gitleaks detect --log-opts HEAD`, which walks *every commit reachable from HEAD*. The `README.md` at the tip no longer spells the placeholder that way, but the commit that did is still walked — so only a commit-anchored fingerprint can clear it.

## Verification

Reproduced the pipeline locally, running both passes exactly as `pipelines/global/scripts/tools/gitleaks/run.sh` does:

```
before →  pass1 (default rules): exit=0 findings=0
          pass2 (gitlab rules) : exit=1 findings=1   ← the failure
after  →  pass1 (default rules): exit=0 findings=0
          pass2 (gitlab rules) : exit=0 findings=0   ← stage exits 0
```

> [!NOTE]
> The PR build itself **cannot** prove this fix. On a pull request the scan is scoped to `origin/main..HEAD`, so it only sees this branch's commits and never walks the historical commit that is failing. Only the post-merge `main` build exercises the allowlist, which is why it was validated locally against the full `HEAD` ancestry as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)