### PR TITLE
fix(ci): pinned the GoReleaser main package to `./cmd/autobump`

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -21,3 +21,4 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/go-binary.yaml@main'
     with:
       binary_name: 'autobump'
+      binary_path: './cmd/autobump'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the `delivery:binary` pipeline job failing and publishing a release with no binaries attached, by pointing
+  GoReleaser at `./cmd/autobump` explicitly. The shared pipeline detects the entry point by grepping for a line
+  starting with `func main()` and taking the first hit, which since the Swagger version-bumping tests is the sample
+  program embedded in `internal/domain/commands/update_version_test.go` rather than `cmd/autobump/main.go`. It built
+  `internal/domain/commands`, a package with no `main` function, so release `2.33.1` shipped with zero assets and
+  `autobump self-update` had nothing to download
+
 ## [2.33.1] - 2026-07-14
 
 ### Changed


### PR DESCRIPTION
## Problem

The `delivery > binary` job has been failing on every `main` build since the Swagger version-bumping tests landed, and [run 29358047458](https://github.com/rios0rios0/autobump/actions/runs/29358047458/job/87171565619) failed with:

```
⨯ release failed after 0s
  │ build failed: build for autobump does not contain a main function
```

`delivery > release` runs first and succeeds, so **release `2.33.1` exists but has zero binary assets** (`2.32.0` has 7). Nothing can be downloaded from it, and `autobump self-update` has nothing to fetch.

## Root cause

`default.yaml` passed only `binary_name`, so `binary_path` fell back to its default of `.`. When that input is `.`, the shared pipeline's `goreleaser/prepare.sh` auto-detects the entry point with a plain text grep:

```bash
DETECTED=$(grep -rl "^func main()" --include="*.go" . | head -1)
```

That grep is purely textual — it does not skip `_test.go`, does not check the package clause, and cannot tell that a match sits inside a string literal. Two files in this repo have a line starting with `func main()`:

| File | What it really is |
|---|---|
| `internal/domain/commands/update_version_test.go:593` | a `func main() {}` inside a backtick raw-string fixture of a sample `main.go` |
| `cmd/autobump/main.go` | the actual entry point |

`grep -r` walks `internal/` before `cmd/`, so `head -1` returned the test fixture and the real entry point never got a look in. The job log confirms it:

```
Auto-detected main package at: ././internal/domain/commands
Generated .goreleaser.yaml for 'autobump' (main: ././internal/domain/commands)
```

`internal/domain/commands` is package `commands`, not `main` — so GoReleaser had nothing to build.

## Fix

Pass `binary_path` explicitly. `prepare.sh` only runs its heuristic when the value is exactly `.`, so an explicit path bypasses the broken detection entirely.

The root cause is being fixed upstream in rios0rios0/pipelines#497, which replaces the grep with a `go list` query for real `main` packages. This PR stands on its own regardless: an explicit entry point does not depend on any heuristic, and it unblocks the next release immediately rather than waiting on the pipelines merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)