### PR TITLE
fix(security): harden test directory permissions to owner-only (resolve Semgrep incorrect-default-permission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
   `internal/domain/commands`, a package with no `main` function, so release `2.33.1` shipped with zero assets and
   `autobump self-update` had nothing to download
 
+### Security
+
+- hardened test-fixture directory permissions from `0o755` to owner-only `0o700` in the update-version and process-repo tests, resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
+
 ## [2.33.1] - 2026-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Security
 
-- hardened test-fixture directory permissions from `0o755` to owner-only `0o700` in the update-version and process-repo tests, resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
+- hardened test-fixture directory permissions from `0o755` to owner-only `0o700` in the update-version and
+  process-repo tests, resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the
+  owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
 
 ## [2.33.1] - 2026-07-14
 

--- a/internal/domain/commands/process_repo_test.go
+++ b/internal/domain/commands/process_repo_test.go
@@ -162,7 +162,9 @@ func TestProcessRepoAdditionalBranches(t *testing.T) { //nolint:tparallel // mut
 		// given
 		repoPath, _ := createTestRepo(t)
 		docsDir := filepath.Join(repoPath, "docs")
-		require.NoError(t, os.MkdirAll(docsDir, 0o700)) //nolint:gosec // test directory needs execute bit for traversal
+		// The docs dir needs the owner execute bit for traversal, so 0o700 is least-privilege.
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(docsDir, 0o700))
 		changelogPath := filepath.Join(docsDir, "CHANGES.md")
 		content := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\n### Added\n\n- added initial release\n"
 		require.NoError(t, os.WriteFile(changelogPath, []byte(content), 0o644))

--- a/internal/domain/commands/update_version_test.go
+++ b/internal/domain/commands/update_version_test.go
@@ -648,8 +648,10 @@ swagger: "2.0"
 `
 
 	docsDir := filepath.Join(projectPath, docsRelDir)
-	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(projectPath, mainRelPath)), 0o755))
-	require.NoError(t, os.MkdirAll(docsDir, 0o755))
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(projectPath, mainRelPath)), 0o700))
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.MkdirAll(docsDir, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, mainRelPath), []byte(mainGoContent), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(docsDir, "docs.go"), []byte(docsGoContent), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(docsDir, "swagger.json"), []byte(swaggerJSONContent), 0o644))
@@ -768,7 +770,8 @@ func TestGetVersionFiles(t *testing.T) {
 	t.Run("should return only files whose content matches a version pattern when globbing", func(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "docs"), 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "docs"), 0o700))
 		require.NoError(t, os.WriteFile(
 			filepath.Join(tmpDir, "main.go"),
 			[]byte("package main\n\nfunc main() {}\n"),

--- a/internal/domain/commands/update_version_test.go
+++ b/internal/domain/commands/update_version_test.go
@@ -648,8 +648,10 @@ swagger: "2.0"
 `
 
 	docsDir := filepath.Join(projectPath, docsRelDir)
+	// A directory needs the owner execute bit; 0o700 is least-privilege (rule's 0o600 is file-only).
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(projectPath, mainRelPath)), 0o700))
+	// A directory needs the owner execute bit; 0o700 is least-privilege (rule's 0o600 is file-only).
 	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	require.NoError(t, os.MkdirAll(docsDir, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, mainRelPath), []byte(mainGoContent), 0o644))
@@ -770,6 +772,7 @@ func TestGetVersionFiles(t *testing.T) {
 	t.Run("should return only files whose content matches a version pattern when globbing", func(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
+		// A directory needs the owner execute bit; 0o700 is least-privilege (rule's 0o600 is file-only).
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "docs"), 0o700))
 		require.NoError(t, os.WriteFile(


### PR DESCRIPTION
## Problem

CI `sast:semgrep` fails on `main` with 4 blocking findings, all of the same rule:

```
go.lang.correctness.permissions.file_permission.incorrect-default-permission
```

The rule (a gosec G301/G302 port, CWE-276) flags `os.Chmod/Mkdir/OpenFile/MkdirAll/ioutil.WriteFile` whenever the mode is **strictly greater than `0o600`**.

## Root cause

All 4 findings are `os.MkdirAll(...)` **directory** creations in test files:

- `internal/domain/commands/update_version_test.go` (3× `0o755`)
- `internal/domain/commands/process_repo_test.go` (1×, already `0o700` with a `//nolint:gosec`)

The `process_repo_test.go` site had already been lowered to `0o700` with a `//nolint:gosec` — proving the intent — but Semgrep ignores `//nolint` directives and still flags `0o700` because a directory *must* keep the owner execute (search) bit (`0o600` dir ⇒ `permission denied`). So the rule's `0o600` threshold cannot be met by a working directory; `0o700` is the least-privilege mode.

## Fix

- **Hardened** the three `0o755` directories to owner-only **`0o700`** (removes group/world access).
- Added a **rule-scoped** `// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission` at each site.
- On the already-`0o700` docs dir, replaced the ineffective `//nolint:gosec` with the `nosemgrep` directive plus its rationale (gosec is already excluded from `_test.go` by the shared lint config, so the `//nolint` was redundant).
- `CHANGELOG.md` updated under `[Unreleased] > Security`.

Verified locally: `golangci-lint` (pipelines config, `unit` tag) `--new-from-rev origin/main` → 0 new issues; `go vet` compiles; `gofmt` clean; the directive suppresses all findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)