### PR TITLE
fix(cleanup): kept the branch when closing its pull request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
   pair stays retryable. Only a genuine close failure keeps a branch: one with no pull request at all
   is still deleted, since having nothing to close is a no-op rather than a failure, and a missing
   token also still deletes, because without one no pull request was ever opened to strand
+- fixed the pull request close call running without a deadline, so an unresponsive provider could
+  stall a release behind cleanup. Each close is now bounded, keeping cleanup best-effort
 
 ## [2.33.2] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed cleanup deleting a stale branch even when closing its pull request had failed, which stranded
   an open pull request whose source branch no longer existed. Because cleanup only considers branches
   that still exist, no later run would have seen it to retry the close; the branch is now kept so the
-  pair stays retryable. A missing token still deletes the branch, because without one no pull request
-  was ever opened to strand
+  pair stays retryable. Only a genuine close failure keeps a branch: one with no pull request at all
+  is still deleted, since having nothing to close is a no-op rather than a failure, and a missing
+  token also still deletes, because without one no pull request was ever opened to strand
 
 ## [2.33.2] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed cleanup to run only once a bump is known to be needed, so a pull request is never closed
   without a replacement being opened for it
+- changed the sample configuration to show `cleanup_stale_branches: false`, since the key is opt-out
+  and `true` is the one value that has no effect
+
+### Fixed
+
+- fixed cleanup deleting a stale branch even when closing its pull request had failed, which stranded
+  an open pull request whose source branch no longer existed. Because cleanup only considers branches
+  that still exist, no later run would have seen it to retry the close; the branch is now kept so the
+  pair stays retryable. A missing token still deletes the branch, because without one no pull request
+  was ever opened to strand
 
 ## [2.33.2] - 2026-07-16
 

--- a/configs/autobump.yaml
+++ b/configs/autobump.yaml
@@ -38,9 +38,9 @@ github_access_token: "ghp_TOKEN"
 # (optional) delete the bump branches left over by earlier runs, closing any pull
 # request attached to them, before creating the branch for the current release.
 # This keeps unattended runs from piling up release branches nobody merged.
-# Enabled by default, so set it to false to keep those branches, or pass
-# --skip-cleanup to disable it for a single run.
-#cleanup_stale_branches: true
+# Enabled by default; uncomment the line below to keep those branches instead,
+# or pass --skip-cleanup to disable it for a single run.
+#cleanup_stale_branches: false
 
 # (optional) prefix of the branches AutoBump creates; the next version is appended
 # to it. The same prefix decides which branches the cleanup above removes.

--- a/internal/domain/commands/cleanup.go
+++ b/internal/domain/commands/cleanup.go
@@ -71,8 +71,16 @@ func cleanupStaleBumpBranches(ctx *RepoContext) {
 	provider, forgeRepo := resolveCleanupProvider(ctx, serviceType, defaultBranch)
 
 	for _, branch := range stale {
-		if provider != nil {
-			closeStalePullRequest(provider, forgeRepo, branch)
+		// A branch whose pull request could not be closed is left alone. Deleting it
+		// would strand an open pull request whose source branch no longer exists, and
+		// because cleanup only looks at branches that still exist, no later run would
+		// see it to try closing it again. Keeping it makes the pair retryable.
+		//
+		// A missing provider is different: without a token the bumper never opened a
+		// pull request in the first place, so there is nothing to strand and the branch
+		// is still worth removing.
+		if provider != nil && !closeStalePullRequest(provider, forgeRepo, branch) {
+			continue
 		}
 
 		if deleteErr := gitInfra.DeleteRemoteBranch(ctx.Repo, branch, authMethods); deleteErr != nil {
@@ -134,17 +142,26 @@ func resolveCleanupProvider(
 // closeStalePullRequest closes the pull request opened from the given branch, if one is
 // still open. It runs before the branch is deleted, because a provider cannot reliably
 // resolve a pull request from a source branch that no longer exists.
+//
+// It reports whether the branch is safe to delete: false means the pull request could not
+// be closed, so the branch must stay for a later run to retry. Finding no open pull
+// request is a success, not a failure.
 func closeStalePullRequest(
 	provider globalEntities.ForgeProvider,
 	forgeRepo globalEntities.Repository,
 	branch string,
-) {
+) bool {
 	closed, err := provider.ClosePullRequest(context.Background(), forgeRepo, branch)
 	if err != nil {
-		logger.Warnf("Could not close the pull request for the branch '%s': %v", branch, err)
-		return
+		logger.Warnf(
+			"Could not close the pull request for the branch '%s', "+
+				"keeping the branch so a later run can retry: %v",
+			branch, err,
+		)
+		return false
 	}
 	if closed {
 		logger.Infof("Closed the pull request for the stale branch '%s'", branch)
 	}
+	return true
 }

--- a/internal/domain/commands/cleanup.go
+++ b/internal/domain/commands/cleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"strings"
+	"time"
 
 	logger "github.com/sirupsen/logrus"
 
@@ -11,6 +12,9 @@ import (
 	gitInfra "github.com/rios0rios0/gitforge/pkg/git/infrastructure"
 	globalEntities "github.com/rios0rios0/gitforge/pkg/global/domain/entities"
 )
+
+// closePullRequestTimeout caps a single close call against the forge API.
+const closePullRequestTimeout = 30 * time.Second
 
 // filterStaleBumpBranches returns the branches AutoBump owns and may safely remove:
 // every branch carrying the bump prefix, except the repository's default branch.
@@ -151,7 +155,13 @@ func closeStalePullRequest(
 	forgeRepo globalEntities.Repository,
 	branch string,
 ) bool {
-	closed, err := provider.ClosePullRequest(context.Background(), forgeRepo, branch)
+	// Bounded so an unresponsive provider cannot hang the release behind housekeeping.
+	// Cleanup runs before the bump and walks every stale branch, so without a deadline a
+	// single hung call would stall the whole run rather than degrading to best-effort.
+	ctx, cancel := context.WithTimeout(context.Background(), closePullRequestTimeout)
+	defer cancel()
+
+	closed, err := provider.ClosePullRequest(ctx, forgeRepo, branch)
 	if err != nil {
 		logger.Warnf(
 			"Could not close the pull request for the branch '%s', "+


### PR DESCRIPTION
## Summary

Follow-up to #275, porting a fix found during review of the same feature in
rios0rios0/autoupdate#215. The identical code shape shipped here.

Cleanup closed a stale branch's pull request and then deleted the branch **even when the close
failed**. That is strictly worse than doing nothing: it strands an open pull request whose source
branch no longer exists, and because cleanup only considers branches that still exist, no later run
would ever see it to retry the close.

## Changes

- `closeStalePullRequest` now reports whether the branch is safe to delete; the caller skips
  deletion when closing failed, so the pair stays retryable on the next run. Finding no open pull
  request still counts as success.
- A **missing** provider still deletes, deliberately: without a token AutoBump never opened a pull
  request in the first place, so there is nothing to strand.
- The sample config now shows `cleanup_stale_branches: false`. The key is opt-out, so `true` was the
  one value with no effect — which read as contradicting the comment describing it as the default.

## Testing

`make lint` — 0 issues. `make test` — exit 0, no failures.

The equivalent behaviour is covered by a test in autoupdate that makes the provider fail the close
and asserts the branch survives; the autobump path has no test harness for a live provider, so this
change is verified by the existing suite plus that cross-repo case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)