### PR TITLE
fix(gitleaks): re-pointed the allowlist fingerprints at the rebased commit

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -16,11 +16,22 @@
 # Allowlisting only one of the two leaves the other pass red, which is what used to
 # fail every `main` build here.
 #
+# Because the fingerprint embeds the commit, a rewritten history invalidates every
+# entry here: a rebase gives the offending commit a new hash, the old fingerprint
+# stops matching anything, and the finding comes back. Re-point the entries at the
+# new hash rather than adding a second set -- the orphaned commit is unreachable
+# from HEAD, so the scan never walks it again.
+#
 # 2026-07-13 -- both entries below are the same documentation placeholder: the
 # batch-mode example in README.md set `project_access_token` to a dummy value that
 # happened to carry the real GitLab prefix followed by the number of characters the
 # rules count, which is all they look for. No credential was ever committed. The
 # README no longer spells the placeholder that way, but the scan still walks the
 # commit that did.
-42a90f886a27f99560a300d024b524b154f7096d:README.md:gitlab-pat:113
-42a90f886a27f99560a300d024b524b154f7096d:README.md:gitlab_personal_access_token:113
+#
+# 2026-07-23 -- re-pointed from 42a90f88 to 38d8dd75. The commit is the same change
+# ("Update README.md and Copilot instructions with accurate information", 2025-12-16);
+# only its hash moved, because the branch it sits on was rebased. 42a90f88 is now
+# unreachable from HEAD. The placeholder itself is unchanged and still not a secret.
+38d8dd7523bb66b7ed3bc988f51c53f0d960afb9:README.md:gitlab-pat:113
+38d8dd7523bb66b7ed3bc988f51c53f0d960afb9:README.md:gitlab_personal_access_token:113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
   token also still deletes, because without one no pull request was ever opened to strand
 - fixed the pull request close call running without a deadline, so an unresponsive provider could
   stall a release behind cleanup. Each close is now bounded, keeping cleanup best-effort
+- fixed the Gitleaks stage failing every build on `main`. The allowlisted fingerprints in
+  `.gitleaksignore` embed the hash of the commit a finding came from, so when a rebase moved the
+  commit holding the `README.md` token placeholder, the entries stopped matching and the
+  long-suppressed false positive came back. Re-pointed both of them at the commit's current hash
 
 ## [2.33.2] - 2026-07-16
 


### PR DESCRIPTION
## Problem

`sast:gitleaks` is the only failing job on `main`, and has been since the merge of #274 (3 consecutive red builds). It fails pass 1 with `leaks found: 1`:

| Rule | File | Match |
|---|---|---|
| `gitlab-pat` | `README.md:113` | `glpat-PROJECT-SPECIFIC-TOK` |

That match is a documentation placeholder, and it was already triaged and allowlisted in `.gitleaksignore` back in July.

## Root cause

Nothing about the finding changed — **the commit it lives in was rebased**, so its hash moved:

```
allowlisted: 42a90f886a27f99560a300d024b524b154f7096d  (now unreachable from HEAD)
reported:    38d8dd7523bb66b7ed3bc988f51c53f0d960afb9  (reachable)
```

Both are the same change ("Update README.md and Copilot instructions with accurate information", 2025-12-16). A `.gitleaksignore` entry is a full fingerprint — `<commit>:<file>:<rule-id>:<line>` — so it embeds the commit hash. When a rebase rewrites that commit, the entry stops matching anything, silently, and the finding resurfaces. Since branch builds scan `--log-opts HEAD` (all history), it fails every build from then on.

## Fix

Re-pointed both entries at the commit's current hash, and added a comment explaining this failure mode so the next occurrence is diagnosable. Both rule ids are updated, because the pipeline scans twice under different rule names and an entry must exist per pass:

- pass 1 — gitleaks default ruleset → `gitlab-pat`
- pass 2 — the GitLab-customised ruleset from `pipelines` → `gitlab_personal_access_token`

No suppression was added or broadened: this is the same placeholder, same file, same line, same two rules as before.

## Verification

⚠️ **CI on this PR does not prove the fix.** The run script scopes PR builds to `origin/main..HEAD`, so a finding from 2025 history is out of scope and the job goes green regardless. Verified locally instead, reproducing exactly what a branch build does (`--log-opts HEAD`, both passes):

| | before | after |
|---|---|---|
| pass 1 (default ruleset) | `leaks found: 1` | `no leaks found` |
| pass 2 (GitLab ruleset) | skipped — pass 1 failed first | `no leaks found` |

317 commits scanned, matching the CI run exactly. Pass 2 mattered here: CI never reached it, so fixing pass 1 alone would have just exposed the next failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)