### PR TITLE
chore(deps): pinned `langforge` to the released `v1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go version to `1.26.6` and updated all module dependencies
+- changed the `langforge` dependency from a commit pseudo-version to the released `v1.0.0`. The Dart support above needed `pkg/infrastructure/languages/dart`, which no published version carried, so the pin had to name a commit until langforge cut a release; it now names a tag like every other dependency. `v1.0.0` removes the per-ecosystem `Provider` structs and the two Java runtime managers, neither of which this repository ever named — it uses `NewDefaultRegistry`, `ClassifyFileByExtension`, the `Language` constants and `dart.BumpBuildNumber`, all unchanged
 - changed the version-file rewrite to resolve its exceptions through a `versionFileHooks` table keyed by file name, instead of branching inside the substitution loop. `pom.xml` keeps masking its `<parent>` block exactly as before and `pubspec.yaml` joins it, so the next exception is a map entry rather than another condition in the engine
 
 ## [2.35.6] - 2026-08-13

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/rios0rios0/cliforge v0.3.14
-	github.com/rios0rios0/langforge v0.6.12-0.20260814122130-74f6ef7dca0c
+	github.com/rios0rios0/langforge v1.0.0
 	github.com/rios0rios0/testkit v0.2.6
 	github.com/sirupsen/logrus v1.10.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/rios0rios0/cliforge v0.3.14 h1:g3hSNyhLFgemWWgO+zzCQvbBprEiIuN2ARhV3j
 github.com/rios0rios0/cliforge v0.3.14/go.mod h1:6+3AwCsoJlSDaw7pu2Qe8S5Jw/059ZBMyZuQVcyFps8=
 github.com/rios0rios0/gitforge v1.0.1-0.20260723213209-a16be141d1d4 h1:SwY8oKLhirdpsRVtA7gsI5hixhJX8C/PxErttDu6zYU=
 github.com/rios0rios0/gitforge v1.0.1-0.20260723213209-a16be141d1d4/go.mod h1:fuwZbZ2YUVzUXy0knyD/wU9YjgZpef2HpCkOVJsSSgg=
-github.com/rios0rios0/langforge v0.6.12-0.20260814122130-74f6ef7dca0c h1:GNCuq/R6EAOY736Uezkc5fe63XTT9JDq8aygV0IBr4Q=
-github.com/rios0rios0/langforge v0.6.12-0.20260814122130-74f6ef7dca0c/go.mod h1:TabMEVXALv2Vvj4Er/4u9mf2SAmzv0xjkB1TxFA7SPo=
+github.com/rios0rios0/langforge v1.0.0 h1:J+5NdV30dDq1LW9jdDQKCeoAuEuUreocosvWbnbu8qQ=
+github.com/rios0rios0/langforge v1.0.0/go.mod h1:TabMEVXALv2Vvj4Er/4u9mf2SAmzv0xjkB1TxFA7SPo=
 github.com/rios0rios0/testkit v0.2.6 h1:JtHkUwxrO3Uog5xYhZTVmdbrjyHEz36Vre3a2SR4yY8=
 github.com/rios0rios0/testkit v0.2.6/go.mod h1:dsQ2xX7nMAOkquTgakoA2/Z2sMBuBkCSEyLZMwpXU/Q=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
Replaces the `langforge` commit pseudo-version with the released **`v1.0.0`**.

## Why it was a pseudo-version

The Dart and Flutter support merged in #296 imports `pkg/infrastructure/languages/dart`, which no published `langforge` carried — `v0.6.11` predates it entirely. The pin therefore had to name a commit, and the review thread on that line was deliberately left open as the reminder to swap it. rios0rios0/langforge#64 has since released `v1.0.0`, so it now names a tag like every other dependency.

## The major boundary does not affect this repository

`v1.0.0` is major because it removes the nine per-ecosystem `Provider` structs (now `repositories.CompositeProvider`) and the two Java `RuntimeManager`s (now a shared `java.RuntimeManager`). AutoBump never named either. It uses:

- `registry.NewDefaultRegistry` and `LanguageRegistry.Detect`
- `entities.ClassifyFileByExtension` and the `Language` constants
- `dart.BumpBuildNumber`

all of which survive unchanged. `go build ./...` and the full suite pass, and the `go.mod` diff is exactly one line — no other dependency moved.

## Verification

`make lint`, `make test` and `make sast` are green (Semgrep 0 findings across 117 rules, Gitleaks clean on both passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
