### PR TITLE
fix(gitleaks): stopped the code-review skill from tripping the secret scanner

### DIFF
--- a/.changes/unreleased/5375857457409520528-1f65.yaml
+++ b/.changes/unreleased/5375857457409520528-1f65.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the `main` pipeline, which every repository''s `sast:gitleaks` job had been failing since the code-review skill landed: the skill''s own security bullet listed credential prefixes verbatim to warn against writing them, and the scanner''s second pass matches those prefixes on their own, so the warning tripped the rule it was describing. The bullet now names the vendors instead, and the commit that carried the original wording is allowlisted by fingerprint in `.gitleaksignore`, because the scan walks the whole history reachable from `HEAD` and no edit at the tip can clear a past commit. No credential was ever committed.'
+time: '2026-08-26T17:30:00.000000000Z'

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -250,10 +250,11 @@ See [Security](https://github.com/rios0rios0/guide/wiki/Security).
 - **No hard-coded secrets.** API keys, tokens, passwords, and private keys belong in
   environment variables or a secret manager — never in source, tests, fixtures, or the
   changelog. A secret that reaches a commit must be rotated, not merely deleted.
-- **Never write a PEM header sentinel or a realistic key shape into a fixture**
-  (`ghp_…`, `sk-…`, `AKIA…`, `xoxb-…`, JWT-shaped strings, or the dashed `BEGIN …` banners).
+- **Never write a PEM header sentinel or a realistic key shape into a fixture** (a GitHub,
+  OpenAI, AWS, or Slack token prefix, JWT-shaped strings, or the dashed `BEGIN …` banners).
   Gitleaks matches the shape, not the value, so a placeholder that merely *looks* like a
-  credential fails the pipeline. Use inert placeholders such as `fixture-token-placeholder`.
+  credential fails the pipeline — spelling those prefixes out here would trip it too. Use
+  inert placeholders such as `fixture-token-placeholder`.
 - **Suppressions must be justified.** Entries in `.gitleaksignore`, `.trivyignore`,
   `.semgrepignore`, or `.codeql-false-positives` need a fingerprint, a dated comment, and a
   reason. A suppression added to silence a real finding is a Critical.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -250,8 +250,8 @@ See [Security](https://github.com/rios0rios0/guide/wiki/Security).
 - **No hard-coded secrets.** API keys, tokens, passwords, and private keys belong in
   environment variables or a secret manager — never in source, tests, fixtures, or the
   changelog. A secret that reaches a commit must be rotated, not merely deleted.
-- **Never write a PEM header sentinel or a realistic key shape into a fixture** (a GitHub,
-  OpenAI, AWS, or Slack token prefix, JWT-shaped strings, or the dashed `BEGIN …` banners).
+- **Never write a PEM header sentinel or a realistic key shape into a fixture** (GitHub,
+  OpenAI, AWS, or Slack token prefixes, JWT-shaped strings, or the dashed `BEGIN …` banners).
   Gitleaks matches the shape, not the value, so a placeholder that merely *looks* like a
   credential fails the pipeline — spelling those prefixes out here would trip it too. Use
   inert placeholders such as `fixture-token-placeholder`.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -35,3 +35,21 @@
 # unreachable from HEAD. The placeholder itself is unchanged and still not a secret.
 38d8dd7523bb66b7ed3bc988f51c53f0d960afb9:README.md:gitlab-pat:113
 38d8dd7523bb66b7ed3bc988f51c53f0d960afb9:README.md:gitlab_personal_access_token:113
+# 2026-08-26 -- false positive raised by gitleaks pass 2, the GitLab-customised ruleset
+# that the pipelines repository supplies. On a branch build the scan walks every commit
+# reachable from HEAD, so a finding survives any edit made at the tip; a fingerprint is
+# the only thing that clears it.
+#
+# The match sits in `.github/skills/code-review/SKILL.md`, inside the very bullet that
+# tells contributors not to commit credential-shaped placeholders. That bullet used to
+# list the vendor prefixes verbatim, and the rule matches the prefix on its own, so the
+# documentation tripped the rule it was documenting. Nothing was ever a credential.
+#
+# The bullet now names the vendors instead of spelling their prefixes, which stops the
+# pattern recurring, but the commit that introduced the original wording is still walked
+# on every build -- hence this entry.
+#
+# The line below is a full fingerprint: <commit>:<file>:<rule-id>:<line>. It embeds the
+# commit hash, so rewriting history invalidates it: re-point the entry at the new hash
+# rather than adding a second one.
+b23a5a974449d0cfd4e8a1a251668376943ffe04:.github/skills/code-review/SKILL.md:Slack token:254


### PR DESCRIPTION
## Root cause

The `sast:gitleaks` job has been failing on `main` since the Copilot code-review skill landed
earlier today. The finding is not a credential — it is the skill's own documentation.

`.github/skills/code-review/SKILL.md` has a Security bullet that tells contributors never to
write credential-shaped placeholders into fixtures. To illustrate the point, it listed the
vendor token prefixes verbatim. The gitleaks job runs two passes, and pass 2 — the
GitLab-customised ruleset that `rios0rios0/pipelines` ships — has a rule that matches one of
those prefixes on its own, with no body check. So the bullet tripped the exact rule it was
documenting.

The same rollout hit **25 repositories** at once; this is that repository's fix.

## Fix

1. **Reworded the bullet** to name the vendors instead of spelling their prefixes, so the
   pattern stops recurring. The guidance is unchanged.
2. **Allowlisted the historical commit by fingerprint** in `.gitleaksignore`.

Step 2 is not optional. On a branch build the scan runs `--log-opts HEAD`, which walks *every
commit reachable from HEAD*, so rewording the file at the tip does not clear a finding that
already exists in history. A commit-anchored fingerprint is the only thing that does:

```
b23a5a974449d0cfd4e8a1a251668376943ffe04:.github/skills/code-review/SKILL.md:Slack token:254
```

Because the fingerprint embeds the commit hash, a rebase of that commit invalidates the entry
and the finding returns — the comment in `.gitleaksignore` records that.

## Verification

Both passes were run locally against the full history of this branch with the same gitleaks
version CI pins (8.30.1), and both report `no leaks found`:

```
gitleaks detect --source . --log-opts HEAD
gitleaks detect --source . --log-opts HEAD --config <pipelines>/global/scripts/tools/gitleaks/.gitleaks.toml
```

Note that a **green check on this PR does not prove the fix**: on a pull request the scan is
scoped to `origin/main..HEAD` and sees only this branch's own commits, never the historical one
being suppressed. The local full-history run above is the real evidence, and the post-merge
`main` build is the confirmation.

## Security note

No credential was ever committed here. The match was documentation text describing what a
credential looks like.