### PR TITLE
chore(claude): pointed the Claude workflows at pipelines

### DIFF
--- a/.changes/unreleased/1787860000000000000-c1de.yaml
+++ b/.changes/unreleased/1787860000000000000-c1de.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'changed the Claude workflows to call the reusable workflows in `rios0rios0/pipelines` instead of `rios0rios0/.github`, which is where every other reusable workflow and composite action already lives, and renamed them to `claude-review.yaml` and `claude-mention.yaml`, matching the `reusable-claude-review.yaml` / `reusable-claude-mention.yaml` definitions they call'
+time: '2026-08-27T18:00:00.000000000Z'

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -1,18 +1,18 @@
-name: 'Claude Code'
+name: 'Claude Mention'
 
 on:
   issue_comment:
-    types: [created]
+    types: ['created']
   pull_request_review_comment:
-    types: [created]
+    types: ['created']
   issues:
-    types: [opened, assigned]
+    types: ['opened', 'assigned']
   pull_request_review:
-    types: [submitted]
+    types: ['submitted']
 
 jobs:
-  claude:
-    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
+  claude-mention:
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-mention.yaml@main'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -2,11 +2,11 @@ name: 'Claude Code Review'
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: ['opened', 'synchronize', 'ready_for_review', 'reopened']
 
 jobs:
   claude-review:
-    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-review.yaml@main'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:


### PR DESCRIPTION
## What

Points this repository's two Claude workflows at their new home and renames them to match. The reusable definitions moved out of `rios0rios0/.github` into [`rios0rios0/pipelines`](https://github.com/rios0rios0/pipelines), beside every other reusable workflow and composite action.

```diff
-  .github/workflows/claude-code-review.yaml
-    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
+  .github/workflows/claude-review.yaml
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-review.yaml@main'
```

```diff
-  .github/workflows/claude.yaml
-    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
+  .github/workflows/claude-mention.yaml
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-mention.yaml@main'
```

Git tracks both as renames, so the history follows.

## Naming

The definition carries a `reusable-` prefix; the caller drops it. So a file named `claude-review.yaml` is always *this repository's* workflow, and `reusable-claude-review.yaml` is always the shared definition it calls — including inside `rios0rios0/pipelines`, which now names its own callers exactly like every other consumer.

| In `rios0rios0/pipelines` | In this repository |
|---|---|
| `reusable-claude-review.yaml` | `claude-review.yaml` |
| `reusable-claude-mention.yaml` | `claude-mention.yaml` |

## Authentication

`CLAUDE_CODE_OAUTH_TOKEN` is passed **explicitly** rather than with `secrets: inherit`, which Semgrep's `yaml.github-actions.security.secrets-inherit` rule fails. This repository already holds the secret.

## Ordering

The definitions are added by **rios0rios0/pipelines#625**. Until that merges, the `Claude Code Review` check here cannot resolve its `uses:` and will fail — re-run it once #625 is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe
