### PR TITLE
fix(sonar): declared test files as test sources for automatic analysis

### DIFF
--- a/.changes/unreleased/1788656691590800265-30c6.yaml
+++ b/.changes/unreleased/1788656691590800265-30c6.yaml
@@ -1,3 +1,3 @@
 kind: 'Fixed'
-body: 'declared test files as test sources for SonarCloud Automatic Analysis so duplicated test setup no longer fails the quality gate'
+body: 'declared test files as test sources for SonarCloud Automatic Analysis in `.sonarcloud.properties`, so duplicated setup in `**/*_test.go` and the support packages under `test/` no longer fails the "Duplication on New Code" quality gate'
 time: '2026-09-06T01:04:51.590599952Z'

--- a/.changes/unreleased/1788656691590800265-30c6.yaml
+++ b/.changes/unreleased/1788656691590800265-30c6.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'declared test files as test sources for SonarCloud Automatic Analysis so duplicated test setup no longer fails the quality gate'
+time: '2026-09-06T01:04:51.590599952Z'

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,11 @@
+# SonarQube Cloud Automatic Analysis configuration.
+#
+# This project is analyzed by Automatic Analysis, which reads only this file
+# (sonar-project.properties is ignored in that mode). Test files were being
+# indexed as production code, so duplicated setup in *_test.go and the test
+# support packages under test/ was failing the "Duplication on New Code"
+# quality-gate condition. Declaring them as test sources fixes that.
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go,**/test/**
+sonar.exclusions=**/*_test.go,**/test/**,**/vendor/**,**/build/**,**/dist/**,**/coverage/**


### PR DESCRIPTION
## Why

`main` fails the SonarCloud Quality Gate on **Duplication on New Code** (threshold 3%). This project is analyzed by SonarCloud Automatic Analysis, which had no test classification configured, so every `*_test.go` file and the `test/` support packages were indexed as production code and their repeated setup blocks counted as duplication. Automatic Analysis reads only `.sonarcloud.properties` (it ignores `sonar-project.properties`), so the fix has to live in that file.

## What changed

- added `.sonarcloud.properties` declaring `**/*_test.go` and `**/test/**` as test sources and excluding them from the source set (plus the usual `vendor`, `build`, `dist`, `coverage` folders)
- added a chlog fragment

## Verification

- file content checked against the SonarCloud Automatic Analysis documentation (supported keys: `sonar.sources`, `sonar.tests`, `sonar.exclusions`, `sonar.test.inclusions`)
- the effect is only visible on the `main` analysis after merge: the PR analysis measures duplication on changed files only
- the remaining failing conditions on `main` (Security Rating C / Security Hotspots Reviewed 0%) come solely from `githubactions:S7637` on the first-party `uses: rios0rios0/pipelines/...@main` references and need a SonarCloud-side acceptance or a switch to CI-based analysis; they are out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBkPLFLrWCPLaEKrS37ah5
