### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.changes/unreleased/1788656912004371882-9f3c.yaml
+++ b/.changes/unreleased/1788656912004371882-9f3c.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'refreshed `.github/copilot-instructions.md` to record the Go module version as `1.27.1`'
+time: '2026-09-07T12:15:12.004371882Z'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,7 +123,7 @@ autobump/
 │   ├── embed.go                         # go:embed of the shipped defaults
 │   └── CHANGELOG.template.md           # Default CHANGELOG template
 ├── Makefile                             # Build: build, debug, build-musl, run, install
-├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.27.0)
+├── go.mod                               # Module: github.com/rios0rios0/autobump (Go 1.27.1)
 └── .github/
     └── workflows/default.yaml           # CI/CD pipeline (go-binary reusable workflow)
 ```


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/skills/code-review/SKILL.md`) against the current code, updated whichever drifted, and recorded the change as a `.changes/unreleased/` fragment (chlog repositories) or under `[Unreleased]` in `CHANGELOG.md` (everywhere else).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.